### PR TITLE
Fix potential blocking

### DIFF
--- a/internal/pkg/crawl/utils.go
+++ b/internal/pkg/crawl/utils.go
@@ -107,7 +107,7 @@ func (c *Crawl) shouldPause(host string) bool {
 	}
 }
 
-func isRedirection(statusCode int) bool {
+func isStatusCodeRedirect(statusCode int) bool {
 	if statusCode == 300 || statusCode == 301 ||
 		statusCode == 302 || statusCode == 307 ||
 		statusCode == 308 {

--- a/internal/pkg/utils/utils.go
+++ b/internal/pkg/utils/utils.go
@@ -37,19 +37,23 @@ func SetupLogging(jobPath string, liveStats bool, esURL string) (logInfo, logWar
 		}
 
 		go func() {
+		newHook:
 			hookInfo, err := elogrus.NewAsyncElasticHook(client, hostname, logrus.InfoLevel, "zeno-"+time.Now().Format("2006.01.02"))
 			if err != nil {
-				logrus.Panic(err)
+				logrus.Error(err)
+				goto newHook
 			}
 
 			hookWarning, err := elogrus.NewAsyncElasticHook(client, hostname, logrus.WarnLevel, "zeno-"+time.Now().Format("2006.01.02"))
 			if err != nil {
-				logrus.Panic(err)
+				logrus.Error(err)
+				goto newHook
 			}
 
 			hookError, err := elogrus.NewAsyncElasticHook(client, hostname, logrus.ErrorLevel, "zeno-"+time.Now().Format("2006.01.02"))
 			if err != nil {
-				logrus.Panic(err)
+				logrus.Error(err)
+				goto newHook
 			}
 
 			logInfo.Hooks.Add(hookInfo)


### PR DESCRIPTION
There was a special case where a worker could be blocked, if it were to follow more redirections than the number of available slots in the crawl pool (the max # of requests that can be done to a given host).

This PR fixes that.