### PR TITLE
Add state management for workers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 jobs/*
+jobs/
 Zeno
 *.txt
 *.sh

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -52,6 +52,7 @@ func InitCrawlWithCMD(flags config.Flags) *crawl.Crawl {
 	c.WorkerPool = make([]*crawl.Worker, 0)
 	c.WorkerStopTimeout = time.Second * 60 // Placeholder for WorkerStopTimeout
 	c.MaxConcurrentAssets = flags.MaxConcurrentAssets
+	c.WorkerStopSignal = make(chan bool)
 
 	c.Seencheck = flags.Seencheck
 	c.HTTPTimeout = flags.HTTPTimeout

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -10,7 +10,6 @@ import (
 	"github.com/internetarchive/Zeno/internal/pkg/frontier"
 	"github.com/internetarchive/Zeno/internal/pkg/utils"
 	"github.com/paulbellamy/ratecounter"
-	"github.com/remeh/sizedwaitgroup"
 	"github.com/sirupsen/logrus"
 )
 
@@ -50,7 +49,8 @@ func InitCrawlWithCMD(flags config.Flags) *crawl.Crawl {
 	c.JobPath = path.Join("jobs", flags.Job)
 
 	c.Workers = flags.Workers
-	c.WorkerPool = sizedwaitgroup.New(c.Workers)
+	c.WorkerPool = make([]*crawl.Worker, 0)
+	c.WorkerStopTimeout = time.Second * 60 // Placeholder for WorkerStopTimeout
 	c.MaxConcurrentAssets = flags.MaxConcurrentAssets
 
 	c.Seencheck = flags.Seencheck

--- a/internal/pkg/crawl/api.go
+++ b/internal/pkg/crawl/api.go
@@ -17,9 +17,10 @@ type APIWorkersState struct {
 }
 
 type APIWorkerState struct {
-	WorkerID  int    `json:"worker_id"`
+	WorkerID  uint   `json:"worker_id"`
 	Status    string `json:"status"`
 	LastError string `json:"last_error"`
+	LastSeen  string `json:"last_seen"`
 	Locked    bool   `json:"locked"`
 }
 
@@ -73,16 +74,24 @@ func (crawl *Crawl) startAPI() {
 		c.JSON(200, workersState)
 	})
 
-	r.GET("/workers/:worker_id", func(c *gin.Context) {
+	r.GET("/worker/:worker_id", func(c *gin.Context) {
 		workerID := c.Param("worker_id")
 		workerIDInt, err := strconv.Atoi(workerID)
 		if err != nil {
+			c.JSON(400, gin.H{
+				"error": "Unsupported worker ID",
+			})
+			return
+		}
+
+		workersState := crawl.GetWorkerState(workerIDInt)
+		if workersState == nil {
 			c.JSON(404, gin.H{
 				"error": "Worker not found",
 			})
 			return
 		}
-		workersState := crawl.GetWorkerState(workerIDInt)
+
 		c.JSON(200, workersState)
 	})
 

--- a/internal/pkg/crawl/crawl.go
+++ b/internal/pkg/crawl/crawl.go
@@ -402,6 +402,9 @@ func (c *Crawl) EnsureWorkersFinished() bool {
 // GetWorkerState returns the state of a worker given its index in the worker pool
 // if the provided index is -1 then the state of all workers is returned
 func (c *Crawl) GetWorkerState(index int) interface{} {
+	c.WorkerMutex.RLock()
+	defer c.WorkerMutex.RUnlock()
+
 	if index == -1 {
 		var workersStatus = new(APIWorkersState)
 		for i, worker := range c.WorkerPool {

--- a/internal/pkg/crawl/finish.go
+++ b/internal/pkg/crawl/finish.go
@@ -32,6 +32,7 @@ func (crawl *Crawl) catchFinish() {
 }
 
 func (crawl *Crawl) finish() {
+	crawl.WorkerStopSignal <- true
 	crawl.Finished.Set(true)
 
 	// First we wait for the queue reader to finish its current work,
@@ -45,7 +46,7 @@ func (crawl *Crawl) finish() {
 	close(crawl.Frontier.PullChan)
 
 	crawl.Logger.Warning("[WORKERS] Waiting for workers to finish")
-	crawl.WorkerPool.Wait()
+	crawl.EnsureWorkersFinished()
 	crawl.Logger.Warning("[WORKERS] All workers finished")
 
 	// When all workers are finished, we can safely close the HQ related channels

--- a/internal/pkg/crawl/worker.go
+++ b/internal/pkg/crawl/worker.go
@@ -46,6 +46,7 @@ type workerState struct {
 
 type Worker struct {
 	sync.Mutex
+	id              uint
 	state           *workerState
 	doneSignal      chan bool
 	crawlParameters *Crawl
@@ -60,7 +61,7 @@ func (w *Worker) Run() {
 		item := item
 
 		// Check if the crawl is paused or needs to be stopped
-		switch {
+		select {
 		case <-w.doneSignal:
 			w.Lock()
 			w.state.currentItem = nil
@@ -121,8 +122,9 @@ func (w *Worker) PushLastError(err error) {
 	w.Unlock()
 }
 
-func newWorker(crawlParameters *Crawl) *Worker {
+func newWorker(crawlParameters *Crawl, id uint) *Worker {
 	return &Worker{
+		id: id,
 		state: &workerState{
 			status:       idle,
 			previousItem: nil,


### PR DESCRIPTION
- Workers are now bound to a an operator-like structure, their state is visible and manipulated through that object
- Workers state is visible using API queries
- Worker state is observed by a routine ensuring consistency

This is the followup of #63 that was used to bring fork changes to the origin repo