### PR TITLE
Fix crash when --api is not set

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -145,9 +145,10 @@ func InitCrawlWithCMD(flags config.Flags) *crawl.Crawl {
 
 	c.API = flags.API
 	c.APIPort = flags.APIPort
-	c.PrometheusMetrics = new(crawl.PrometheusMetrics)
-	c.PrometheusMetrics.Prefix = flags.PrometheusPrefix
-
+	if c.API {
+		c.PrometheusMetrics = new(crawl.PrometheusMetrics)
+		c.PrometheusMetrics.Prefix = flags.PrometheusPrefix
+	}
 	if flags.UserAgent != "Zeno" {
 		c.UserAgent = flags.UserAgent
 	} else {

--- a/internal/pkg/crawl/capture.go
+++ b/internal/pkg/crawl/capture.go
@@ -36,7 +36,9 @@ func (c *Crawl) executeGET(item *frontier.Item, req *http.Request, isRedirection
 	)
 
 	defer func() {
-		c.PrometheusMetrics.DownloadedURI.Inc()
+		if c.PrometheusMetrics != nil {
+			c.PrometheusMetrics.DownloadedURI.Inc()
+		}
 
 		c.URIsPerSecond.Incr(1)
 


### PR DESCRIPTION
Prometheus was always expecting to be present but API is not always set when crawls are ran, resulting in Prometheus not being correctly defined. This resolves that issue.