### PR TITLE
Change log location

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -75,7 +75,7 @@ func getCMDsFlags(getCmd *cobra.Command) {
 
 	// Logging flags
 	getCmd.PersistentFlags().Bool("live-stats", false, "Enable live stats but disable logging. (implies --no-stdout-log)")
-	getCmd.PersistentFlags().String("log-file-output-dir", "./jobs/", "Directory to write log files to.")
+	getCmd.PersistentFlags().String("log-file-output-dir", "./jobs/logs/", "Directory to write log files to.")
 	getCmd.PersistentFlags().String("es-url", "", "comma-separated ElasticSearch URL to use for indexing crawl logs.")
 	getCmd.PersistentFlags().String("es-user", "", "ElasticSearch username to use for indexing crawl logs.")
 	getCmd.PersistentFlags().String("es-password", "", "ElasticSearch password to use for indexing crawl logs.")


### PR DESCRIPTION
## Changes made
I updated the directory where log files are written from ./jobs/ to ./jobs/logs/. Previously, logs were being written directly to the /jobs directory, which was not the intended location. By changing the path to ./jobs/logs/, the logs will now be stored in the designated subdirectory, improving organization and making it easier to manage log files. This update helps ensure that logs are kept separate from other files in the /jobs directory, adhering to a cleaner and more logical directory structure.

##Screenshots
![Screenshot from 2024-07-23 10-46-17](https://github.com/user-attachments/assets/5c2595e0-4078-4f80-9433-67542c040d0c)

## Issue Resolved
Fixes https://github.com/internetarchive/Zeno/issues/73