### PR TITLE
Implement linkheader parsing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,6 @@ require (
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.9.0
 	github.com/telanflow/cookiejar v0.0.0-20190719062046-114449e86aa5
-	github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80
 	github.com/zeebo/xxh3 v1.0.2
 	go.uber.org/goleak v1.3.0
 	golang.org/x/net v0.26.0

--- a/go.sum
+++ b/go.sum
@@ -182,8 +182,6 @@ github.com/syndtr/goleveldb v1.0.0 h1:fBdIW9lB4Iz0n9khmH8w27SJ3QEJ7+IgjPEwGSZiFd
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
 github.com/telanflow/cookiejar v0.0.0-20190719062046-114449e86aa5 h1:gTQl5nPlc9B53vFOKM8aJHwxB2BW2kM49PVR5526GBg=
 github.com/telanflow/cookiejar v0.0.0-20190719062046-114449e86aa5/go.mod h1:qNgA5MKwTh103SxGTooqZMiKxZTaV9UV3KjN7I7Drig=
-github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80 h1:nrZ3ySNYwJbSpD6ce9duiP+QkD3JuLCcWkdaehUS/3Y=
-github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80/go.mod h1:iFyPdL66DjUD96XmzVL3ZntbzcflLnznH0fr99w5VqE=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
 github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=

--- a/internal/pkg/crawl/capture.go
+++ b/internal/pkg/crawl/capture.go
@@ -22,7 +22,6 @@ import (
 	"github.com/internetarchive/Zeno/internal/pkg/crawl/sitespecific/vk"
 	"github.com/internetarchive/Zeno/internal/pkg/utils"
 	"github.com/remeh/sizedwaitgroup"
-	"github.com/tomnomnom/linkheader"
 
 	"github.com/internetarchive/Zeno/internal/pkg/frontier"
 )
@@ -338,7 +337,7 @@ func (c *Crawl) Capture(item *frontier.Item) error {
 
 	// Scrape potential URLs from Link HTTP header
 	var (
-		links      = linkheader.Parse(resp.Header.Get("link"))
+		links      = Parse(resp.Header.Get("link"))
 		discovered []string
 	)
 

--- a/internal/pkg/crawl/link_header.go
+++ b/internal/pkg/crawl/link_header.go
@@ -43,6 +43,7 @@ func Parse(link string) []Link {
 	return links
 }
 
+// Parse a single attribute key value pair and return it
 func ParseAttr(attrs string) (key, value string) {
 	attrRegex := regexp.MustCompile(`^(\S+)=\"(\S+)\"$`)
 	match := attrRegex.FindStringSubmatch(attrs)

--- a/internal/pkg/crawl/link_header.go
+++ b/internal/pkg/crawl/link_header.go
@@ -1,0 +1,51 @@
+package crawl
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Represents a Link struct, containing a URL to which it links, and a Rel to define the relation
+type Link struct {
+	URL string
+	Rel string
+}
+
+// Parse parses a raw Link header in the form:
+//
+//	<url1>; rel="what", <url2>; rel="any"; another="yes", <url3>; rel="thing"
+//
+// returning a slice of Link structs
+// Each of these are separated by a `, ` and the in turn by a `; `, with the first always being the url, and the remaining the key-val pairs
+// See: https://simon-frey.com/blog/link-header/, https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Link
+func Parse(link string) []Link {
+	var links []Link
+
+	urlRegex := regexp.MustCompile(`^<(\S+)>$`)
+	// var linkRegex = regexp.MustCompile(`^<(\S+)>(; (\S+)=(\S+))*$`)
+
+	for _, link := range strings.Split(link, ", ") {
+		parts := strings.Split(link, "; ")
+		match := urlRegex.FindStringSubmatch(parts[0])
+		url := match[1]
+		rel := ""
+
+		for _, attrs := range parts[1:] {
+			key, value := ParseAttr(attrs)
+			if key == "rel" {
+				rel = value
+				break
+			}
+		}
+		links = append(links, Link{URL: url, Rel: rel})
+	}
+
+	return links
+}
+
+func ParseAttr(attrs string) (key, value string) {
+	attrRegex := regexp.MustCompile(`^(\S+)=\"(\S+)\"$`)
+	match := attrRegex.FindStringSubmatch(attrs)
+
+	return match[1], match[2]
+}

--- a/internal/pkg/crawl/link_header_test.go
+++ b/internal/pkg/crawl/link_header_test.go
@@ -1,0 +1,39 @@
+package crawl
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestParseOneLink(t *testing.T) {
+	var links []Link
+	links = append(links, Link{URL: "https://one.example.com", Rel: "preconnect"})
+
+	var link = `<https://one.example.com>; rel="preconnect"`
+
+	got := Parse(link)
+	want := links
+
+	if !slices.Equal(got, want) {
+		t.Errorf("got %q, wanted %q", got, want)
+	}
+}
+
+func TestParseMultipleLinks(t *testing.T) {
+
+	var links []Link
+	links = append(links,
+		Link{URL: "https://test.com", Rel: "preconnect"},
+		Link{URL: "https://app.test.com", Rel: "preconnect"},
+		Link{URL: "https://example.com", Rel: "preconnect"},
+	)
+
+	var link = `<https://test.com>; rel="preconnect", <https://app.test.com>; rel="preconnect"; foo="bar", <https://example.com>; rel="preconnect"`
+
+	got := Parse(link)
+	want := links
+
+	if !slices.Equal(got, want) {
+		t.Errorf("got %q, wanted %q", got, want)
+	}
+}

--- a/internal/pkg/crawl/link_header_test.go
+++ b/internal/pkg/crawl/link_header_test.go
@@ -37,17 +37,64 @@ func TestParseMultipleLinks(t *testing.T) {
 	}
 }
 
+func TestParseOneMalformedLink(t *testing.T) {
+	var links []Link
+	links = append(links, Link{URL: "https://one.example.com", Rel: "preconnect"})
+
+	var link = `https://one.example.com>;; rel=preconnect";`
+
+	got := Parse(link)
+	want := links
+
+	if !slices.Equal(got, want) {
+		t.Errorf("got %q, wanted %q", got, want)
+	}
+}
+
+func TestParseMultipleMalformedLinks(t *testing.T) {
+	var links []Link
+	links = append(links,
+		Link{URL: "", Rel: "preconnect"},
+		Link{URL: "https://app.test.com", Rel: ""},
+		Link{URL: "", Rel: ""},
+	)
+
+	var link = `; rel="preconnect", https://app.test.com; rel=""; "bar", <>; ="preconnect"`
+
+	got := Parse(link)
+	want := links
+
+	if !slices.Equal(got, want) {
+		t.Errorf("got %q, wanted %q", got, want)
+	}
+}
+
 func TestParseAttr(t *testing.T) {
 	attr := `rel="preconnect"`
 
 	gotKey, gotValue := ParseAttr(attr)
 	wantKey, wantValue := "rel", "preconnect"
 
-	if (gotKey != wantKey) {
+	if gotKey != wantKey {
 		t.Errorf("got %q, wanted %q", gotKey, wantKey)
 	}
 
-	if  (gotValue != wantValue) {
+	if gotValue != wantValue {
+		t.Errorf("got %q, wanted %q", gotValue, wantValue)
+	}
+}
+
+func TestParseMalformedAttr(t *testing.T) {
+	attr := `="preconnect"`
+
+	gotKey, gotValue := ParseAttr(attr)
+	wantKey, wantValue := "", "preconnect"
+
+	if gotKey != wantKey {
+		t.Errorf("got %q, wanted %q", gotKey, wantKey)
+	}
+
+	if gotValue != wantValue {
 		t.Errorf("got %q, wanted %q", gotValue, wantValue)
 	}
 }

--- a/internal/pkg/crawl/link_header_test.go
+++ b/internal/pkg/crawl/link_header_test.go
@@ -20,7 +20,6 @@ func TestParseOneLink(t *testing.T) {
 }
 
 func TestParseMultipleLinks(t *testing.T) {
-
 	var links []Link
 	links = append(links,
 		Link{URL: "https://test.com", Rel: "preconnect"},
@@ -35,5 +34,20 @@ func TestParseMultipleLinks(t *testing.T) {
 
 	if !slices.Equal(got, want) {
 		t.Errorf("got %q, wanted %q", got, want)
+	}
+}
+
+func TestParseAttr(t *testing.T) {
+	attr := `rel="preconnect"`
+
+	gotKey, gotValue := ParseAttr(attr)
+	wantKey, wantValue := "rel", "preconnect"
+
+	if (gotKey != wantKey) {
+		t.Errorf("got %q, wanted %q", gotKey, wantKey)
+	}
+
+	if  (gotValue != wantValue) {
+		t.Errorf("got %q, wanted %q", gotValue, wantValue)
 	}
 }


### PR DESCRIPTION
This PR adds a Parse function for linkheader parsing, therefore removing the dependency on `github.com/tomnomnom/linkheader`. This also includes writing unit tests for the function

Closes #85 