### PR TITLE
create url_string_test.go

### DIFF
--- a/internal/pkg/utils/url_string.go
+++ b/internal/pkg/utils/url_string.go
@@ -25,6 +25,7 @@ func URLToString(u *url.URL) string {
 		tempHost = u.Hostname()
 	}
 
+	// Handle IPv6 Address Formatting
 	if strings.Contains(tempHost, ":") && !(strings.HasPrefix(tempHost, "[") && strings.HasSuffix(tempHost, "]")) {
 		tempHost = "[" + tempHost + "]"
 	}

--- a/internal/pkg/utils/url_string_test.go
+++ b/internal/pkg/utils/url_string_test.go
@@ -66,6 +66,12 @@ func TestURLToString(t *testing.T) {
 			expectErr: false,
 			expected:  "http://xn--fa-hia.de",
 		},
+		{
+			name:      "URL with IPv6 address",
+			input:     "http://[2001:db8::1]:8080",
+			expectErr: false,
+			expected:  "http://[2001:db8::1]:8080",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/pkg/utils/url_string_test.go
+++ b/internal/pkg/utils/url_string_test.go
@@ -1,0 +1,88 @@
+package utils
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestURLToString(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		expectErr bool
+		expected  string
+	}{
+		{
+			name:      "Valid URL with query",
+			input:     "http://bing.com/search?q=dotnet",
+			expectErr: false,
+			expected:  "http://bing.com/search?q=dotnet",
+		},
+		{
+			name:      "Valid URL without query",
+			input:     "http://example.com",
+			expectErr: false,
+			expected:  "http://example.com",
+		},
+		{
+			name:      "URL with port",
+			input:     "http://localhost:8080",
+			expectErr: false,
+			expected:  "http://localhost:8080",
+		},
+		{
+			name:      "URL with path",
+			input:     "http://example.com/path/to/resource",
+			expectErr: false,
+			expected:  "http://example.com/path/to/resource",
+		},
+		{
+			name:      "Invalid URL without scheme",
+			input:     "://missing-scheme.com",
+			expectErr: true,
+			expected:  "",
+		},
+		{
+			name:      "URL with fragment",
+			input:     "http://example.com/path#section",
+			expectErr: false,
+			expected:  "http://example.com/path#section",
+		},
+		{
+			name:      "URL with IDN domain",
+			input:     "http://xn--fsq.com",
+			expectErr: false,
+			expected:  "http://xn--fsq.com",
+		},
+		{
+			name:      "URL with unicode domain",
+			input:     "http://bücher.de",
+			expectErr: false,
+			expected:  "http://xn--bcher-kva.de",
+		},
+		{
+			name:      "URL with another unicode domain",
+			input:     "http://faß.de",
+			expectErr: false,
+			expected:  "http://xn--fa-hia.de",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u, err := url.Parse(tt.input)
+			if (err != nil) != tt.expectErr {
+				t.Fatalf("Error parsing input string: %s, err: %v", tt.input, err)
+			}
+			if err == nil && tt.expectErr {
+				t.Fatalf("Expected an error for input string: %s, but got none", tt.input)
+			}
+			if err == nil {
+				result := URLToString(u)
+				if result != tt.expected {
+					t.Errorf("Result was incorrect, got: %s, want: %s", result, tt.expected)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Pretty straightforward testing for `URLToString` function. But I'm still not quite sure what the following logic in `URLToString` does so I wasn't able to write a test for it ([link](https://github.com/internetarchive/Zeno/blob/main/internal/pkg/utils/url_string.go#L28)):

```golang
if strings.Contains(tempHost, ":") && !(strings.HasPrefix(tempHost, "[") && strings.HasSuffix(tempHost, "]")) {
	tempHost = "[" + tempHost + "]"
}
```

@NGTmeaty Because you wrote it, could you add a test that verifies the above code is functioning as intended?