### PR TITLE
Implement host rotation and Enqueue/Dequeue access regulation via atomic booleans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Zeno
 *.sh
 zeno.log
 .vscode/
+*.py

--- a/internal/pkg/crawl/finish.go
+++ b/internal/pkg/crawl/finish.go
@@ -26,6 +26,9 @@ func (crawl *Crawl) catchFinish() {
 func (crawl *Crawl) finish() {
 	crawl.Finished.Set(true)
 
+	crawl.Log.Warn("[QUEUE] Freezing the dequeue")
+	crawl.Queue.FreezeDequeue()
+
 	crawl.Log.Warn("[WORKERS] Waiting for workers to finish")
 	crawl.Workers.StopSignal <- true
 	crawl.Workers.EnsureFinished()

--- a/internal/pkg/crawl/stats.go
+++ b/internal/pkg/crawl/stats.go
@@ -36,6 +36,8 @@ func (c *Crawl) printLiveStats() {
 		stats.AddRow("  - URI/s:", c.URIsPerSecond.Rate())
 		stats.AddRow("  - Queued:", c.Queue.GetStats().TotalElements)
 		stats.AddRow("  - Queue empty bool state:", c.Queue.Empty.Get())
+		stats.AddRow("  - Can Enqueue:", c.Queue.CanEnqueue())
+		stats.AddRow("  - Can Dequeue:", c.Queue.CanDequeue())
 		stats.AddRow("  - Hosts in queue:", c.Queue.GetStats().UniqueHosts)
 		stats.AddRow("  - Crawled total:", crawledSeeds+crawledAssets)
 		stats.AddRow("  - Crawled seeds:", crawledSeeds)

--- a/internal/pkg/crawl/worker.go
+++ b/internal/pkg/crawl/worker.go
@@ -89,6 +89,9 @@ func (w *Worker) Run() {
 				w.state.lastAction = "queue is empty"
 				time.Sleep(5 * time.Second)
 			}
+			if err == queue.ErrQueueClosed {
+				w.state.lastAction = "queue is closed"
+			}
 			continue
 		}
 

--- a/internal/pkg/queue/access.go
+++ b/internal/pkg/queue/access.go
@@ -1,0 +1,9 @@
+package queue
+
+func (q *PersistentGroupedQueue) CanEnqueue() bool {
+	return !q.closed.Get()
+}
+
+func (q *PersistentGroupedQueue) CanDequeue() bool {
+	return !q.closed.Get() && !q.finishing.Get()
+}

--- a/internal/pkg/queue/access_test.go
+++ b/internal/pkg/queue/access_test.go
@@ -1,0 +1,43 @@
+package queue
+
+import (
+	"os"
+	"path"
+	"testing"
+)
+
+func Test_canEnqueue(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "queue_test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	q, err := NewPersistentGroupedQueue(path.Join(tempDir, "test_queue"))
+	if err != nil {
+		t.Fatalf("Failed to create new queue: %v", err)
+	}
+	defer q.Close()
+
+	if !q.CanEnqueue() {
+		t.Fatalf("Expected canEnqueue to return true, got false")
+	}
+}
+
+func Test_canDequeue(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "queue_test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	q, err := NewPersistentGroupedQueue(path.Join(tempDir, "test_queue"))
+	if err != nil {
+		t.Fatalf("Failed to create new queue: %v", err)
+	}
+	defer q.Close()
+
+	if !q.CanDequeue() {
+		t.Fatalf("Expected canDequeue to return true, got false")
+	}
+}

--- a/internal/pkg/queue/dequeue.go
+++ b/internal/pkg/queue/dequeue.go
@@ -2,6 +2,7 @@ package queue
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/internetarchive/Zeno/internal/pkg/queue/index"
 )
@@ -9,42 +10,31 @@ import (
 // Dequeue removes and returns the next item from the queue
 // It blocks until an item is available
 func (q *PersistentGroupedQueue) Dequeue() (*Item, error) {
-	if q.closed {
+	if !q.CanDequeue() {
 		return nil, ErrQueueClosed
 	}
 
 	var (
 		position = uint64(0)
 		size     = uint64(0)
-		err      error
+		errPop   error
 	)
 
-	if q.Empty.Get() {
-		return nil, ErrQueueEmpty
+	host, err := q.getNextHost()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get next host: %w", err)
+	}
+
+	_, position, size, errPop = q.index.Pop(host)
+	if errPop != nil && errPop != index.ErrHostEmpty {
+		if errPop == index.ErrHostNotFound {
+			return q.Dequeue() // Try again with another host, this one might be empty due to the non-blocking nature of getNextHost
+		}
+		return nil, fmt.Errorf("failed to pop item from host %s: %w", host, errPop)
 	}
 
 	q.mutex.Lock()
 	defer q.mutex.Unlock()
-
-	hosts := q.index.GetHosts()
-
-	if len(hosts) == 0 {
-		q.Empty.Set(true)
-		return nil, ErrQueueEmpty
-	}
-
-	for _, host := range hosts {
-		_, position, size, err = q.index.Pop(host)
-		if err != nil {
-			if err == index.ErrHostEmpty {
-				continue
-			} else if err == index.ErrHostNotFound {
-				return nil, fmt.Errorf("host %s not found in index, this indicates a failure in index package logic", host)
-			}
-			return nil, fmt.Errorf("failed to pop item from host %s: %w", host, err)
-		}
-		break
-	}
 
 	if position == 0 && size == 0 {
 		q.Empty.Set(true)
@@ -65,4 +55,31 @@ func (q *PersistentGroupedQueue) Dequeue() (*Item, error) {
 	q.updateDequeueStats(item.URL.Host)
 
 	return item, nil
+}
+
+// getNextHost returns the next host to dequeue from
+// It blocks until a host is available, allowing other goroutines to enqueue without keeping the queue mutex locked
+func (q *PersistentGroupedQueue) getNextHost() (string, error) {
+	for q.Empty.Get() && q.CanDequeue() {
+		time.Sleep(1 * time.Second)
+	}
+
+	// If the queue is closed or finishing, we end the wait loop
+	if !q.CanDequeue() {
+		return "", ErrQueueClosed
+	}
+
+	// Get a copy of the hosts
+	hosts := q.index.GetHosts()
+
+	// If there are no hosts, we wait for one to be added
+	if len(hosts) == 0 {
+		q.Empty.Set(true)
+		return q.getNextHost()
+	}
+
+	// Magic operating : get the next host to dequeue from
+	i := q.currentHost.Load() % uint64(len(hosts))
+	q.currentHost.Add(1)
+	return hosts[i], nil
 }

--- a/internal/pkg/queue/enqueue.go
+++ b/internal/pkg/queue/enqueue.go
@@ -11,7 +11,7 @@ func (q *PersistentGroupedQueue) Enqueue(item *Item) error {
 		return errors.New("cannot enqueue nil item")
 	}
 
-	if q.closed {
+	if !q.CanEnqueue() {
 		return ErrQueueClosed
 	}
 

--- a/internal/pkg/queue/metadata.go
+++ b/internal/pkg/queue/metadata.go
@@ -16,7 +16,7 @@ func (q *PersistentGroupedQueue) loadMetadata() error {
 
 	var metadata struct {
 		Stats       QueueStats
-		CurrentHost int
+		CurrentHost uint64
 	}
 
 	err = q.metadataDecoder.Decode(&metadata)
@@ -28,7 +28,7 @@ func (q *PersistentGroupedQueue) loadMetadata() error {
 		return fmt.Errorf("failed to decode metadata: %w", err)
 	}
 
-	q.currentHost = metadata.CurrentHost
+	q.currentHost.Store(metadata.CurrentHost)
 	q.stats = &metadata.Stats
 
 	// Reinitialize maps if they're nil

--- a/internal/pkg/queue/queue_test.go
+++ b/internal/pkg/queue/queue_test.go
@@ -47,7 +47,7 @@ func TestNewPersistentGroupedQueue(t *testing.T) {
 	if len(q.index.GetHosts()) != 0 {
 		t.Error("hostOrder not initialized as empty")
 	}
-	if q.currentHost != 0 {
+	if q.currentHost.Load() != 0 {
 		t.Error("currentHost not initialized to 0")
 	}
 }


### PR DESCRIPTION
# Host rotation
The goal here is to distribute hosts to dequeue from to each worker to avoid repeatedly hitting the same domain while crawling thus avoiding any rate-limiting and ventilate the RPS as much as possible between different hosts
## Initial Challenge
The task was to find an efficient method for distributing numbers (`i` for `hosts[i]`) within an interval `[0,len(hosts)]` that can change over time, based on an atomic uint64 counter that increments with each iteration (dequeue). The goal was to achieve a uniform distribution while maintaining high performance.

To facilitate understanding we will name the atomic uint64 counter : `x` and the interval : `y`

### Key Requirements
1. Perfect coverage of the interval
2. Low execution time
3. Uniformity of distribution

### Methodology
We implemented and tested eight different distribution methods:
1. Simple Modulo (`x%y`)
2. Double Modulo (`x%(x%y)`)
3. Linear Congruential Generator 
4. Xorshift
5. Prime Multiply
6. Wang-Jenkins
7. Fibonacci
8. Block Permutation

These methods were evaluated using a sample size of 100 million random inputs ranging representing `x` from 0 to 2^60 - 1, distributing into 150 bins, representing `y`.

## Results
All methods except Double Modulo showed excellent uniformity and perfect coverage. The performance varied significantly among the methods.

### Key Findings:
1. Simple Modulo emerged as the best overall method, offering:
   - Perfect coverage
   - Fastest execution time (41.44 seconds)
   - Excellent uniformity (Coefficient of Variation: 0.0011)

2. Prime Multiply and Fibonacci also performed well, with slightly longer execution times (48.99 and 49.11 seconds respectively) but equally good uniformity and coverage.

3. Double Modulo performed poorly, showing significant non-uniformity and leaving empty bins.

4. More complex methods like Wang-Jenkins, while providing good uniformity, had significantly longer execution times.

The results can be visually observed with a heatmap:  
![distributions](https://github.com/user-attachments/assets/192f32d5-e9b3-4ecc-8086-6d10f3f51107)


## Conclusion:
Simple Modulo was identified as the optimal method for this specific use case. It offers the best balance of perfect coverage, high performance, and excellent uniformity. Its simplicity also contributes to ease of implementation, maintainability, and portability across different systems and programming languages.

It effectively addresses the challenge of distributing numbers in a dynamically changing interval using an incrementing uint64 counter, providing both efficiency and uniformity in the distribution process.


# Enqueue/Dequeue access regulation
To further enhance the queue performances and stability two atomic booleans were added to the `PersistentGroupedQueue` type to provide control over the state of the queue. Two functions `CanEnqueue()` and `CanDequeue()` were also added to get the state of the queue.    
The `Dequeue()` function now checks if it's allowed to dequeue, catching whenever Zeno is finishing, allowing workers to enqueue their last URLs prior to returning with a `queue.ErrQueueClosed` error triggered by `CanDequeue() = false`, facilitating the finishing process.  

## Benchmarks
Before changes :
```log
Running benchmarks for Enqueue-Dequeue...
Notes:
    - an operation can be either an Enqueue or a Dequeue
    - ns/op is the average time taken per batch
goos: darwin
goarch: arm64
pkg: github.com/internetarchive/Zeno/internal/pkg/queue
BenchmarkEnqueueDequeue/EnqueueDequeue-10                    1    253605415167 ns/op             1.000 batches        100000 operations           394.3 ops/s
--- BENCH: BenchmarkEnqueueDequeue/EnqueueDequeue-10
    queue_test.go:346: ——————————————————————— RUN 1 ———————————————————————
    queue_test.go:374: Queue file size (megabytes): 10
    queue_test.go:377: Enqueue time for 50000 items: 1m53.343481083s
    queue_test.go:398: Dequeue time for 50000 items: 2m20.248690709s
    queue_test.go:399: Average enqueue time per item: 2.266869ms
    queue_test.go:400: Average dequeue time per item: 2.804973ms
PASS
ok      github.com/internetarchive/Zeno/internal/pkg/queue    253.841s
```

After changes :
```log
Running benchmarks for Enqueue-Dequeue...
Notes:
	- an operation can be either an Enqueue or a Dequeue
	- ns/op is the average time taken per batch
goos: darwin
goarch: arm64
pkg: github.com/internetarchive/Zeno/internal/pkg/queue
BenchmarkEnqueueDequeue/EnqueueDequeue-10         	       1	264612467250 ns/op	        1.000 batches	   100000 operations	    377.9 ops/s
--- BENCH: BenchmarkEnqueueDequeue/EnqueueDequeue-10
    queue_test.go:346: ——————————————————————— RUN 1 ———————————————————————
    queue_test.go:375: Queue file size (megabytes): 10
    queue_test.go:378: Enqueue time for 50000 items: 2m11.310019042s
    queue_test.go:400: Dequeue time for 50000 items: 2m13.293973459s
    queue_test.go:401: Average enqueue time per item: 2.6262ms
    queue_test.go:402: Average dequeue time per item: 2.665879ms
PASS
ok  	github.com/internetarchive/Zeno/internal/pkg/queue	264.848s
```