### PR TITLE
Have `queue.Enqueue()` handover items to idle workers and optimize workers routines

### DIFF
--- a/internal/pkg/queue/handover.go
+++ b/internal/pkg/queue/handover.go
@@ -1,0 +1,29 @@
+package queue
+
+type HandoverChannel struct {
+	ch chan *Item
+}
+
+func NewHandoverChannel() *HandoverChannel {
+	return &HandoverChannel{
+		ch: make(chan *Item, 1), // Buffer of 1 for non-blocking operations
+	}
+}
+
+func (h *HandoverChannel) TryPut(item *Item) bool {
+	select {
+	case h.ch <- item:
+		return true
+	default:
+		return false
+	}
+}
+
+func (h *HandoverChannel) TryGet() (*Item, bool) {
+	select {
+	case item := <-h.ch:
+		return item, true
+	default:
+		return nil, false
+	}
+}

--- a/internal/pkg/queue/queue.go
+++ b/internal/pkg/queue/queue.go
@@ -30,6 +30,8 @@ type PersistentGroupedQueue struct {
 	currentHost     *atomic.Uint64
 	mutex           sync.RWMutex
 
+	Handover *HandoverChannel
+
 	closed    *utils.TAtomBool
 	finishing *utils.TAtomBool
 
@@ -75,6 +77,8 @@ func NewPersistentGroupedQueue(queueDirPath string) (*PersistentGroupedQueue, er
 
 		closed:    new(utils.TAtomBool),
 		finishing: new(utils.TAtomBool),
+
+		Handover: NewHandoverChannel(),
 
 		queueDirPath:    queueDirPath,
 		queueFile:       file,


### PR DESCRIPTION
# Handover Process and Use of runtime.Gosched()
## Handover Process
We've implemented a new "handover" mechanism to optimize item processing in our high-performance crawling system. Here's how it works:

1. When new items are received, we attempt an immediate handover to available workers before enqueueing.
2. We use a buffered channel (HandoverChannel) with a capacity of 1 for this purpose.
3. The process loops through each item in a batch:  
    - If the handover channel is empty, we put the item in for immediate processing.
    - If the channel is full, we encode then batch the item for later enqueueing.
4. After processing all items, we check if an item is still in the handover channel. If so, we move it out of the handover channel and encode then batch for enqueueing.

This approach prioritizes immediate processing when workers are available, minimizing latency and reducing pressure on the main queue.
## Use of `runtime.Gosched()`
We've introduced `runtime.Gosched()` in our worker loop for scenarios when no work is immediately available. Here's why:
1. Purpose: `runtime.Gosched()` yields the processor, allowing other goroutines to run.
2. When used: After checking both the handover channel and the main queue, if no work is found.
3. Benefits:
    - Prevents tight-loop spinning, reducing CPU usage when idle.
    - Allows other goroutines (even system/invisible ones) to run.
    - Improves overall system responsiveness and resource utilization.
4. Performance implications:
    - Very lightweight compared to `time.Sleep()`.
    - Minimal impact on latency when work becomes available.
    - Helps balance CPU usage across the system.

It's important to note that `runtime.Gosched()` doesn't block the goroutine; it simply puts it at the back of the run queue. This means our workers remain highly responsive to new work while being more cooperative with other system components.