### PR TITLE
Remove `runtime.Gosched()` in polling

### DIFF
--- a/internal/pkg/crawl/worker.go
+++ b/internal/pkg/crawl/worker.go
@@ -133,7 +133,7 @@ func (w *Worker) Run() {
 // unsafeCapture is named like so because it should only be called when the worker is locked
 func (w *Worker) unsafeCapture(item *queue.Item) {
 	if item == nil {
-		panic("Item is nil")
+		return
 	}
 
 	// Signals that the worker is processing an item

--- a/internal/pkg/crawl/worker.go
+++ b/internal/pkg/crawl/worker.go
@@ -1,7 +1,6 @@
 package crawl
 
 import (
-	"runtime"
 	"sync"
 	"time"
 
@@ -78,7 +77,7 @@ func (w *Worker) Run() {
 				w.state.lastAction = "waiting for queue to be filled"
 			}
 			if (w.pool.Crawl.Paused.Get() || w.pool.Crawl.Queue.Empty.Get()) && w.pool.Crawl.Queue.CanDequeue() {
-				runtime.Gosched()
+				time.Sleep(10 * time.Millisecond)
 				continue
 			}
 		}
@@ -134,7 +133,7 @@ func (w *Worker) Run() {
 // unsafeCapture is named like so because it should only be called when the worker is locked
 func (w *Worker) unsafeCapture(item *queue.Item) {
 	if item == nil {
-		return
+		panic("Item is nil")
 	}
 
 	// Signals that the worker is processing an item
@@ -158,7 +157,7 @@ func (w *Worker) unsafeCapture(item *queue.Item) {
 func (w *Worker) Stop() {
 	w.doneSignal <- true
 	for w.state.status != completed {
-		runtime.Gosched()
+		time.Sleep(10 * time.Millisecond)
 	}
 }
 


### PR DESCRIPTION
revert #101

Do not use `runtime.Gosched()` in loop, which will spinning your CPUs time for endless coroutine context switching. It won't magically turn polling into blocking.

In addition, Golang's coroutines are preemptive since Go1.14. There will be no starving coroutines, we don't need to manually call `runtime.Gosched()` nowadays.