### PR TITLE
Queue handover v2

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -56,6 +56,7 @@ func getCMDsFlags(getCmd *cobra.Command) {
 	getCmd.PersistentFlags().StringSlice("exclude-string", []string{}, "Discard any (discovered) URLs containing this string.")
 	getCmd.PersistentFlags().Bool("random-local-ip", false, "Use random local IP for requests. (will be ignored if a proxy is set)")
 	getCmd.PersistentFlags().Int("min-space-required", 20, "Minimum space required in GB to continue the crawl.")
+	getCmd.PersistentFlags().Bool("use-handover", false, "Use handover mechanism to dispatch URLs via a buffer before enqueuing on disk.")
 
 	// Proxy flags
 	getCmd.PersistentFlags().String("proxy", "", "Proxy to use when requesting pages.")

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -56,7 +56,7 @@ func getCMDsFlags(getCmd *cobra.Command) {
 	getCmd.PersistentFlags().StringSlice("exclude-string", []string{}, "Discard any (discovered) URLs containing this string.")
 	getCmd.PersistentFlags().Bool("random-local-ip", false, "Use random local IP for requests. (will be ignored if a proxy is set)")
 	getCmd.PersistentFlags().Int("min-space-required", 20, "Minimum space required in GB to continue the crawl.")
-	getCmd.PersistentFlags().Bool("use-handover", false, "Use handover mechanism to dispatch URLs via a buffer before enqueuing on disk.")
+	getCmd.PersistentFlags().Bool("handover", false, "Use handover mechanism to dispatch URLs via a buffer before enqueuing on disk.")
 
 	// Proxy flags
 	getCmd.PersistentFlags().String("proxy", "", "Proxy to use when requesting pages.")

--- a/config/config.go
+++ b/config/config.go
@@ -74,7 +74,7 @@ type Config struct {
 	HQContinuousPull               bool     `mapstructure:"hq-continuous-pull"`
 	HQRateLimitSendBack            bool     `mapstructure:"hq-rate-limiting-send-back"`
 	NoStdoutLogging                bool     `mapstructure:"no-stdout-log"`
-	UseHandover                    bool     `mapstructure:"use-handover"`
+	Handover                       bool     `mapstructure:"handover"`
 }
 
 var (

--- a/config/config.go
+++ b/config/config.go
@@ -74,6 +74,7 @@ type Config struct {
 	HQContinuousPull               bool     `mapstructure:"hq-continuous-pull"`
 	HQRateLimitSendBack            bool     `mapstructure:"hq-rate-limiting-send-back"`
 	NoStdoutLogging                bool     `mapstructure:"no-stdout-log"`
+	UseHandover                    bool     `mapstructure:"use-handover"`
 }
 
 var (

--- a/internal/pkg/crawl/api.go
+++ b/internal/pkg/crawl/api.go
@@ -21,11 +21,12 @@ type APIWorkersState struct {
 
 // APIWorkerState represents the state of an API worker.
 type APIWorkerState struct {
-	WorkerID  string `json:"worker_id"`
-	Status    string `json:"status"`
-	LastError string `json:"last_error"`
-	LastSeen  string `json:"last_seen"`
-	Locked    bool   `json:"locked"`
+	WorkerID   string `json:"worker_id"`
+	Status     string `json:"status"`
+	LastError  string `json:"last_error"`
+	LastSeen   string `json:"last_seen"`
+	LastAction string `json:"last_action"`
+	Locked     bool   `json:"locked"`
 }
 
 // startAPI starts the API server for the crawl

--- a/internal/pkg/crawl/config.go
+++ b/internal/pkg/crawl/config.go
@@ -273,7 +273,7 @@ func GenerateCrawlConfig(config *config.Config) (*Crawl, error) {
 	c.HQRateLimitingSendBack = config.HQRateLimitSendBack
 
 	// Handover mechanism
-	c.UseHandover = config.UseHandover
+	c.UseHandover = config.Handover
 
 	return c, nil
 }

--- a/internal/pkg/crawl/config.go
+++ b/internal/pkg/crawl/config.go
@@ -35,6 +35,7 @@ type Crawl struct {
 	Queue        *queue.PersistentGroupedQueue
 	Seencheck    *seencheck.Seencheck
 	UseSeencheck bool
+	UseHandover  bool
 
 	// Worker pool
 	Workers *WorkerPool
@@ -270,6 +271,9 @@ func GenerateCrawlConfig(config *config.Config) (*Crawl, error) {
 	c.HQBatchSize = int(config.HQBatchSize)
 	c.HQContinuousPull = config.HQContinuousPull
 	c.HQRateLimitingSendBack = config.HQRateLimitSendBack
+
+	// Handover mechanism
+	c.UseHandover = config.UseHandover
 
 	return c, nil
 }

--- a/internal/pkg/crawl/crawl.go
+++ b/internal/pkg/crawl/crawl.go
@@ -47,7 +47,7 @@ func (c *Crawl) Start() (err error) {
 
 	// Initialize the queue & seencheck
 	c.Log.Info("Initializing queue and seencheck..")
-	c.Queue, err = queue.NewPersistentGroupedQueue(path.Join(c.JobPath, "queue"))
+	c.Queue, err = queue.NewPersistentGroupedQueue(path.Join(c.JobPath, "queue"), c.UseHandover)
 	if err != nil {
 		c.Log.Fatal("unable to init queue", "error", err)
 	}

--- a/internal/pkg/crawl/hq.go
+++ b/internal/pkg/crawl/hq.go
@@ -152,7 +152,7 @@ func (c *Crawl) HQConsumer() {
 		// This is on purpose evaluated every time,
 		// because the value of workers will maybe change
 		// during the crawl in the future (to be implemented)
-		var HQBatchSize = int(math.Ceil(float64(c.Workers.Count) * 2))
+		var HQBatchSize = int(math.Ceil(float64(c.Workers.Count) / 2))
 
 		if c.Finished.Get() {
 			c.Log.Error("crawl finished, stopping HQ consumer")
@@ -161,8 +161,8 @@ func (c *Crawl) HQConsumer() {
 
 		// If HQContinuousPull is set to true, we will pull URLs from HQ continuously,
 		// otherwise we will only pull URLs when needed (and when the crawl is not paused)
-		for (uint64(c.Queue.GetStats().TotalElements) > uint64(c.Workers.Count)*2 && !c.HQContinuousPull) || c.Paused.Get() {
-			time.Sleep(time.Millisecond * 1)
+		for (uint64(c.Queue.GetStats().TotalElements) > uint64(HQBatchSize) && !c.HQContinuousPull) || c.Paused.Get() {
+			time.Sleep(time.Millisecond * 10)
 			continue
 		}
 

--- a/internal/pkg/crawl/stats.go
+++ b/internal/pkg/crawl/stats.go
@@ -38,7 +38,10 @@ func (c *Crawl) printLiveStats() {
 		stats.AddRow("  - URI/s:", c.URIsPerSecond.Rate())
 		stats.AddRow("  - Items in queue:", queueStats.TotalElements)
 		stats.AddRow("  - Hosts in queue:", queueStats.UniqueHosts)
-		stats.AddRow("  - Handover Get() success:", queueStats.HandoverSuccessGetCount)
+		if c.UseHandover {
+			stats.AddRow("  - Handover open:", c.Queue.HandoverOpen.Get())
+			stats.AddRow("  - Handover Get() success:", queueStats.HandoverSuccessGetCount)
+		}
 		stats.AddRow("  - Queue empty bool state:", c.Queue.Empty.Get())
 		stats.AddRow("  - Can Enqueue:", c.Queue.CanEnqueue())
 		stats.AddRow("  - Can Dequeue:", c.Queue.CanDequeue())
@@ -64,7 +67,7 @@ func (c *Crawl) printLiveStats() {
 
 		fmt.Fprintln(writer, stats.String())
 		writer.Flush()
-		time.Sleep(time.Second * 1)
+		time.Sleep(time.Millisecond * 250)
 	}
 }
 

--- a/internal/pkg/crawl/worker.go
+++ b/internal/pkg/crawl/worker.go
@@ -83,13 +83,8 @@ func (w *Worker) Run() {
 			}
 		}
 
-		// Try to get a handover item first
-		var err error
-		item, ok := w.pool.Crawl.Queue.Handover.TryGet()
-		if !ok {
-			// If the handover is empty, we try to get an item from the queue
-			item, err = w.pool.Crawl.Queue.Dequeue()
-		}
+		// Try to get an item from the queue or handover channel
+		item, err := w.pool.Crawl.Queue.Dequeue()
 		if err != nil {
 			// Log the error too?
 			w.state.lastError = err

--- a/internal/pkg/crawl/worker_pool.go
+++ b/internal/pkg/crawl/worker_pool.go
@@ -131,11 +131,12 @@ func _getWorkerState(worker *Worker) *APIWorkerState {
 	}
 
 	return &APIWorkerState{
-		WorkerID:  worker.ID.String(),
-		Status:    worker.state.status.String(),
-		LastSeen:  worker.state.lastSeen.Format(time.RFC3339),
-		LastError: lastErr,
-		Locked:    isLocked,
+		WorkerID:   worker.ID.String(),
+		Status:     worker.state.status.String(),
+		LastSeen:   worker.state.lastSeen.Format(time.RFC3339),
+		LastError:  lastErr,
+		LastAction: worker.state.lastAction,
+		Locked:     isLocked,
 	}
 }
 

--- a/internal/pkg/queue/access_test.go
+++ b/internal/pkg/queue/access_test.go
@@ -13,7 +13,7 @@ func Test_canEnqueue(t *testing.T) {
 	}
 	defer os.RemoveAll(tempDir)
 
-	q, err := NewPersistentGroupedQueue(path.Join(tempDir, "test_queue"))
+	q, err := NewPersistentGroupedQueue(path.Join(tempDir, "test_queue"), false)
 	if err != nil {
 		t.Fatalf("Failed to create new queue: %v", err)
 	}
@@ -31,7 +31,7 @@ func Test_canDequeue(t *testing.T) {
 	}
 	defer os.RemoveAll(tempDir)
 
-	q, err := NewPersistentGroupedQueue(path.Join(tempDir, "test_queue"))
+	q, err := NewPersistentGroupedQueue(path.Join(tempDir, "test_queue"), false)
 	if err != nil {
 		t.Fatalf("Failed to create new queue: %v", err)
 	}

--- a/internal/pkg/queue/dequeue.go
+++ b/internal/pkg/queue/dequeue.go
@@ -13,8 +13,8 @@ func (q *PersistentGroupedQueue) Dequeue() (*Item, error) {
 		return nil, ErrDequeueClosed
 	}
 
-	if q.handoverCircuitBreaker.Get() {
-		if item, ok := q.handover.TryGet(); ok {
+	if q.HandoverOpen.Get() {
+		if item, ok := q.handover.tryGet(); ok && item != nil {
 			q.handoverCount.Add(1)
 			return item.item, nil
 		}
@@ -67,7 +67,6 @@ func (q *PersistentGroupedQueue) Dequeue() (*Item, error) {
 }
 
 // getNextHost returns the next host to dequeue from
-// WIP _ NON It blocks until a host is available, allowing other goroutines to enqueue without keeping the queue mutex locked
 func (q *PersistentGroupedQueue) getNextHost() (string, error) {
 	if q.Empty.Get() && q.CanDequeue() {
 		return "", ErrQueueEmpty

--- a/internal/pkg/queue/dequeue.go
+++ b/internal/pkg/queue/dequeue.go
@@ -13,6 +13,13 @@ func (q *PersistentGroupedQueue) Dequeue() (*Item, error) {
 		return nil, ErrDequeueClosed
 	}
 
+	if q.handoverCircuitBreaker.Get() {
+		if item, ok := q.handover.TryGet(); ok {
+			q.handoverCount.Add(1)
+			return item.item, nil
+		}
+	}
+
 	var (
 		position = uint64(0)
 		size     = uint64(0)

--- a/internal/pkg/queue/dequeue_test.go
+++ b/internal/pkg/queue/dequeue_test.go
@@ -16,7 +16,7 @@ func TestDequeue(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	// Create a new queue
-	q, err := NewPersistentGroupedQueue(tempDir)
+	q, err := NewPersistentGroupedQueue(tempDir, false)
 	if err != nil {
 		t.Fatalf("Failed to create queue: %v", err)
 	}
@@ -90,7 +90,7 @@ func TestDequeueHostOrder(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	// Create a new queue
-	q, err := NewPersistentGroupedQueue(tempDir)
+	q, err := NewPersistentGroupedQueue(tempDir, false)
 	if err != nil {
 		t.Fatalf("Failed to create queue: %v", err)
 	}

--- a/internal/pkg/queue/enqueue_test.go
+++ b/internal/pkg/queue/enqueue_test.go
@@ -16,7 +16,7 @@ func TestEnqueue(t *testing.T) {
 		}
 		defer os.RemoveAll(tempDir)
 
-		q, err := NewPersistentGroupedQueue(path.Join(tempDir, "test_queue"))
+		q, err := NewPersistentGroupedQueue(path.Join(tempDir, "test_queue"), 0)
 		if err != nil {
 			t.Fatalf("Failed to create new queue: %v", err)
 		}

--- a/internal/pkg/queue/enqueue_test.go
+++ b/internal/pkg/queue/enqueue_test.go
@@ -16,7 +16,7 @@ func TestEnqueue(t *testing.T) {
 		}
 		defer os.RemoveAll(tempDir)
 
-		q, err := NewPersistentGroupedQueue(path.Join(tempDir, "test_queue"), 0)
+		q, err := NewPersistentGroupedQueue(path.Join(tempDir, "test_queue"))
 		if err != nil {
 			t.Fatalf("Failed to create new queue: %v", err)
 		}

--- a/internal/pkg/queue/enqueue_test.go
+++ b/internal/pkg/queue/enqueue_test.go
@@ -16,7 +16,7 @@ func TestEnqueue(t *testing.T) {
 		}
 		defer os.RemoveAll(tempDir)
 
-		q, err := NewPersistentGroupedQueue(path.Join(tempDir, "test_queue"))
+		q, err := NewPersistentGroupedQueue(path.Join(tempDir, "test_queue"), false)
 		if err != nil {
 			t.Fatalf("Failed to create new queue: %v", err)
 		}
@@ -53,7 +53,7 @@ func TestEnqueue(t *testing.T) {
 		}
 		defer os.RemoveAll(tempDir)
 
-		q, err := NewPersistentGroupedQueue(path.Join(tempDir, "test_queue"))
+		q, err := NewPersistentGroupedQueue(path.Join(tempDir, "test_queue"), false)
 		if err != nil {
 			t.Fatalf("Failed to create new queue: %v", err)
 		}
@@ -98,7 +98,7 @@ func TestEnqueue(t *testing.T) {
 		}
 		defer os.RemoveAll(tempDir)
 
-		q, err := NewPersistentGroupedQueue(path.Join(tempDir, "test_queue"))
+		q, err := NewPersistentGroupedQueue(path.Join(tempDir, "test_queue"), false)
 		if err != nil {
 			t.Fatalf("Failed to create new queue: %v", err)
 		}
@@ -124,7 +124,7 @@ func TestEnqueue(t *testing.T) {
 		}
 		defer os.RemoveAll(tempDir)
 
-		q, err := NewPersistentGroupedQueue(path.Join(tempDir, "test_queue"))
+		q, err := NewPersistentGroupedQueue(path.Join(tempDir, "test_queue"), false)
 		if err != nil {
 			t.Fatalf("Failed to create new queue: %v", err)
 		}
@@ -176,7 +176,7 @@ func TestEnqueue(t *testing.T) {
 		}
 		defer os.RemoveAll(tempDir)
 
-		q, err := NewPersistentGroupedQueue(path.Join(tempDir, "test_queue"))
+		q, err := NewPersistentGroupedQueue(path.Join(tempDir, "test_queue"), false)
 		if err != nil {
 			t.Fatalf("Failed to create new queue: %v", err)
 		}
@@ -220,7 +220,7 @@ func TestBatchEnqueue(t *testing.T) {
 		}
 		defer os.RemoveAll(tempDir)
 
-		q, err := NewPersistentGroupedQueue(path.Join(tempDir, "test_queue"))
+		q, err := NewPersistentGroupedQueue(path.Join(tempDir, "test_queue"), false)
 		if err != nil {
 			t.Fatalf("Failed to create new queue: %v", err)
 		}
@@ -261,7 +261,7 @@ func TestBatchEnqueue(t *testing.T) {
 		}
 		defer os.RemoveAll(tempDir)
 
-		q, err := NewPersistentGroupedQueue(path.Join(tempDir, "test_queue"))
+		q, err := NewPersistentGroupedQueue(path.Join(tempDir, "test_queue"), false)
 		if err != nil {
 			t.Fatalf("Failed to create new queue: %v", err)
 		}
@@ -309,7 +309,7 @@ func TestBatchEnqueue(t *testing.T) {
 		}
 		defer os.RemoveAll(tempDir)
 
-		q, err := NewPersistentGroupedQueue(path.Join(tempDir, "test_queue"))
+		q, err := NewPersistentGroupedQueue(path.Join(tempDir, "test_queue"), false)
 		if err != nil {
 			t.Fatalf("Failed to create new queue: %v", err)
 		}
@@ -334,7 +334,7 @@ func TestBatchEnqueue(t *testing.T) {
 		}
 		defer os.RemoveAll(tempDir)
 
-		q, err := NewPersistentGroupedQueue(path.Join(tempDir, "test_queue"))
+		q, err := NewPersistentGroupedQueue(path.Join(tempDir, "test_queue"), false)
 		if err != nil {
 			t.Fatalf("Failed to create new queue: %v", err)
 		}
@@ -389,7 +389,7 @@ func TestBatchEnqueue(t *testing.T) {
 		}
 		defer os.RemoveAll(tempDir)
 
-		q, err := NewPersistentGroupedQueue(path.Join(tempDir, "test_queue"))
+		q, err := NewPersistentGroupedQueue(path.Join(tempDir, "test_queue"), false)
 		if err != nil {
 			t.Fatalf("Failed to create new queue: %v", err)
 		}

--- a/internal/pkg/queue/handover.go
+++ b/internal/pkg/queue/handover.go
@@ -43,6 +43,9 @@ func (h *HandoverChannel) TryClose() bool {
 }
 
 func (h *HandoverChannel) TryPut(item *handoverEncodedItem) bool {
+	if !h.open.Load() {
+		return false
+	}
 	select {
 	case h.ch <- item:
 		return true
@@ -52,6 +55,9 @@ func (h *HandoverChannel) TryPut(item *handoverEncodedItem) bool {
 }
 
 func (h *HandoverChannel) TryGet() (*handoverEncodedItem, bool) {
+	if !h.open.Load() {
+		return nil, false
+	}
 	select {
 	case item := <-h.ch:
 		return item, true

--- a/internal/pkg/queue/handover.go
+++ b/internal/pkg/queue/handover.go
@@ -2,11 +2,18 @@ package queue
 
 import (
 	"sync/atomic"
+	"time"
 )
 
-type HandoverChannel struct {
-	ch   chan *handoverEncodedItem // channel for handover
-	open *atomic.Bool              // whether the channel is open or not
+type handoverChannel struct {
+	ch                  chan *handoverEncodedItem
+	open                *atomic.Bool
+	ready               *atomic.Bool
+	drained             *atomic.Bool
+	signalConsumerDone  chan bool
+	activityTracker     *activityTracker
+	activityTrackerSize int
+	monitorInterval     *atomic.Value // stores time.Duration
 }
 
 type handoverEncodedItem struct {
@@ -14,36 +21,85 @@ type handoverEncodedItem struct {
 	item  *Item
 }
 
-func NewHandoverChannel() *HandoverChannel {
-	handover := &HandoverChannel{
-		ch:   make(chan *handoverEncodedItem),
-		open: new(atomic.Bool),
+type activityTracker struct {
+	buffer []*int64
+	size   int
+	head   atomic.Uint64
+}
+
+func newActivityTracker(size int) *activityTracker {
+	buffer := make([]*int64, size)
+	for i := range buffer {
+		buffer[i] = new(int64)
 	}
+	return &activityTracker{
+		buffer: buffer,
+		size:   size,
+	}
+}
+
+func (at *activityTracker) record(value int64) {
+	head := at.head.Add(1) % uint64(at.size)
+	atomic.StoreInt64(at.buffer[head], value)
+}
+
+func (at *activityTracker) sum() int64 {
+	var sum int64
+	for _, v := range at.buffer {
+		sum += atomic.LoadInt64(v)
+	}
+	return sum
+}
+
+func newHandoverChannel() *handoverChannel {
+	handover := &handoverChannel{
+		ch:                  make(chan *handoverEncodedItem),
+		open:                new(atomic.Bool),
+		ready:               new(atomic.Bool),
+		drained:             new(atomic.Bool),
+		signalConsumerDone:  make(chan bool, 1),
+		monitorInterval:     new(atomic.Value),
+		activityTrackerSize: 5, // 5 intervals
+	}
+	handover.monitorInterval.Store(10 * time.Millisecond)
 	handover.open.Store(false)
 	close(handover.ch)
 	return handover
 }
 
-func (h *HandoverChannel) TryOpen(size int) bool {
-	if h.open.Load() {
+func (h *handoverChannel) tryOpen(size int) bool {
+	if !h.open.CompareAndSwap(false, true) {
 		return false
 	}
 	h.ch = make(chan *handoverEncodedItem, size)
 	h.open.Store(true)
+	h.ready.Store(true)
+	h.drained.Store(false)
+	h.activityTracker = newActivityTracker(h.activityTrackerSize)
+	go h.monitorActivity()
 	return true
 }
 
-func (h *HandoverChannel) TryClose() bool {
-	if !h.open.Load() {
+func (h *handoverChannel) tryClose() bool {
+	if !h.open.CompareAndSwap(true, false) || h.ready.Load() || h.drained.Load() {
 		return false
 	}
+	select {
+	case item := <-h.ch:
+		if item != nil {
+			panic("handover channel not drained") // This should never happen
+		}
+	default:
+		break
+	}
 	close(h.ch)
-	h.open.Store(false)
+	h.activityTracker = nil
+	h.monitorInterval.Store(10 * time.Millisecond)
 	return true
 }
 
-func (h *HandoverChannel) TryPut(item *handoverEncodedItem) bool {
-	if !h.open.Load() {
+func (h *handoverChannel) tryPut(item *handoverEncodedItem) bool {
+	if !h.ready.Load() || !h.open.Load() {
 		return false
 	}
 	select {
@@ -54,14 +110,68 @@ func (h *HandoverChannel) TryPut(item *handoverEncodedItem) bool {
 	}
 }
 
-func (h *HandoverChannel) TryGet() (*handoverEncodedItem, bool) {
-	if !h.open.Load() {
+func (h *handoverChannel) tryGet() (*handoverEncodedItem, bool) {
+	if !h.ready.Load() || !h.open.Load() {
 		return nil, false
 	}
 	select {
 	case item := <-h.ch:
+		if item == nil {
+			return nil, true
+		}
+		h.activityTracker.record(1)
 		return item, true
 	default:
 		return nil, false
+	}
+}
+
+func (h *handoverChannel) tryDrain() ([]*handoverEncodedItem, bool) {
+	if !h.open.Load() {
+		return nil, false
+	}
+
+	items := []*handoverEncodedItem{}
+	ok := false
+	for {
+		select {
+		case item := <-h.ch:
+			if item == nil {
+				continue
+			}
+			items = append(items, item)
+			ok = true
+		default:
+			h.drained.Store(true)
+			return items, ok
+		}
+	}
+}
+
+func (h *handoverChannel) monitorActivity() {
+	for h.open.Load() {
+		interval := h.monitorInterval.Load().(time.Duration)
+		time.Sleep(interval)
+
+		activity := h.activityTracker.sum()
+		h.activityTracker.record(0)
+
+		if activity == 0 {
+			h.ready.Store(false)
+			// Grace period
+			time.Sleep(20 * time.Millisecond)
+			if h.activityTracker.sum() == 0 {
+				h.signalConsumerDone <- true
+				return
+			}
+			h.ready.Store(true)
+		}
+
+		// Adjust monitoring interval based on activity
+		if activity > 10 {
+			h.monitorInterval.Store(20 * time.Millisecond)
+		} else if activity < 2 {
+			h.monitorInterval.Store(5 * time.Millisecond)
+		}
 	}
 }

--- a/internal/pkg/queue/handover.go
+++ b/internal/pkg/queue/handover.go
@@ -5,9 +5,8 @@ import (
 )
 
 type HandoverChannel struct {
-	ch    chan *handoverEncodedItem
-	count *atomic.Uint64
-	open  *atomic.Bool
+	ch   chan *handoverEncodedItem // channel for handover
+	open *atomic.Bool              // whether the channel is open or not
 }
 
 type handoverEncodedItem struct {
@@ -17,9 +16,8 @@ type handoverEncodedItem struct {
 
 func NewHandoverChannel() *HandoverChannel {
 	handover := &HandoverChannel{
-		ch:    make(chan *handoverEncodedItem),
-		count: new(atomic.Uint64),
-		open:  new(atomic.Bool),
+		ch:   make(chan *handoverEncodedItem),
+		open: new(atomic.Bool),
 	}
 	handover.open.Store(false)
 	close(handover.ch)
@@ -56,11 +54,8 @@ func (h *HandoverChannel) TryPut(item *handoverEncodedItem) bool {
 func (h *HandoverChannel) TryGet() (*handoverEncodedItem, bool) {
 	select {
 	case item := <-h.ch:
-		h.count.Add(1)
 		return item, true
 	default:
 		return nil, false
 	}
 }
-
-func (h *HandoverChannel) Drain()

--- a/internal/pkg/queue/handover_test.go
+++ b/internal/pkg/queue/handover_test.go
@@ -1,0 +1,94 @@
+package queue
+
+import "testing"
+
+func TestNewHandover(t *testing.T) {
+	handover := NewHandoverChannel()
+	if handover == nil {
+		t.Fatal("expected handover channel to be created")
+	}
+
+	if handover.open.Load() {
+		t.Fatal("expected handover channel to be closed")
+	}
+}
+
+func TestHandoverTryOpen(t *testing.T) {
+	handover := NewHandoverChannel()
+	if !handover.TryOpen(1) {
+		t.Fatal("expected handover channel to be opened")
+	}
+
+	if !handover.open.Load() {
+		t.Fatal("expected handover channel to be open")
+	}
+
+	if handover.TryOpen(1) {
+		t.Fatal("expected handover channel to not be opened again")
+	}
+}
+
+func TestHandoverTryClose(t *testing.T) {
+	handover := NewHandoverChannel()
+	if handover.TryClose() {
+		t.Fatal("expected handover channel to not be closed")
+	}
+
+	if !handover.TryOpen(1) {
+		t.Fatal("expected handover channel to be opened")
+	}
+
+	if !handover.TryClose() {
+		t.Fatal("expected handover channel to be closed")
+	}
+
+	if handover.TryClose() {
+		t.Fatal("expected handover channel to not be closed again")
+	}
+}
+
+func TestHandoverTryPut(t *testing.T) {
+	handover := NewHandoverChannel()
+	if handover.TryPut(&handoverEncodedItem{}) {
+		t.Fatal("expected handover channel to not be open")
+	}
+
+	if !handover.TryOpen(1) {
+		t.Fatal("expected handover channel to be opened")
+	}
+
+	if !handover.TryPut(&handoverEncodedItem{}) {
+		t.Fatal("expected handover channel to accept item")
+	}
+
+	if handover.TryPut(&handoverEncodedItem{}) {
+		t.Fatal("expected handover channel to not accept item")
+	}
+}
+
+func TestHandoverTryGet(t *testing.T) {
+	handover := NewHandoverChannel()
+	if _, ok := handover.TryGet(); ok {
+		t.Fatal("expected handover channel to not be open")
+	}
+
+	if !handover.TryOpen(1) {
+		t.Fatal("expected handover channel to be opened")
+	}
+
+	if _, ok := handover.TryGet(); ok {
+		t.Fatal("expected handover channel to not have any items")
+	}
+
+	if !handover.TryPut(&handoverEncodedItem{}) {
+		t.Fatal("expected handover channel to accept item")
+	}
+
+	if _, ok := handover.TryGet(); !ok {
+		t.Fatal("expected handover channel to have item")
+	}
+
+	if _, ok := handover.TryGet(); ok {
+		t.Fatal("expected handover channel to not have any items")
+	}
+}

--- a/internal/pkg/queue/handover_test.go
+++ b/internal/pkg/queue/handover_test.go
@@ -3,7 +3,7 @@ package queue
 import "testing"
 
 func TestNewHandover(t *testing.T) {
-	handover := NewHandoverChannel()
+	handover := newHandoverChannel()
 	if handover == nil {
 		t.Fatal("expected handover channel to be created")
 	}
@@ -14,8 +14,8 @@ func TestNewHandover(t *testing.T) {
 }
 
 func TestHandoverTryOpen(t *testing.T) {
-	handover := NewHandoverChannel()
-	if !handover.TryOpen(1) {
+	handover := newHandoverChannel()
+	if !handover.tryOpen(1) {
 		t.Fatal("expected handover channel to be opened")
 	}
 
@@ -23,72 +23,76 @@ func TestHandoverTryOpen(t *testing.T) {
 		t.Fatal("expected handover channel to be open")
 	}
 
-	if handover.TryOpen(1) {
+	if handover.tryOpen(1) {
 		t.Fatal("expected handover channel to not be opened again")
 	}
 }
 
 func TestHandoverTryClose(t *testing.T) {
-	handover := NewHandoverChannel()
-	if handover.TryClose() {
+	handover := newHandoverChannel()
+	if handover.tryClose() {
 		t.Fatal("expected handover channel to not be closed")
 	}
 
-	if !handover.TryOpen(1) {
+	if !handover.tryOpen(1) {
 		t.Fatal("expected handover channel to be opened")
 	}
 
-	if !handover.TryClose() {
-		t.Fatal("expected handover channel to be closed")
+	if handover.tryClose() {
+		t.Fatal("expected tryClose() to fail when handover is not drained")
 	}
 
-	if handover.TryClose() {
+	if _, ok := handover.tryDrain(); ok {
+		t.Fatal("expected handover channel to be drained")
+	}
+
+	if handover.tryClose() {
 		t.Fatal("expected handover channel to not be closed again")
 	}
 }
 
 func TestHandoverTryPut(t *testing.T) {
-	handover := NewHandoverChannel()
-	if handover.TryPut(&handoverEncodedItem{}) {
+	handover := newHandoverChannel()
+	if handover.tryPut(&handoverEncodedItem{}) {
 		t.Fatal("expected handover channel to not be open")
 	}
 
-	if !handover.TryOpen(1) {
+	if !handover.tryOpen(1) {
 		t.Fatal("expected handover channel to be opened")
 	}
 
-	if !handover.TryPut(&handoverEncodedItem{}) {
+	if !handover.tryPut(&handoverEncodedItem{}) {
 		t.Fatal("expected handover channel to accept item")
 	}
 
-	if handover.TryPut(&handoverEncodedItem{}) {
+	if handover.tryPut(&handoverEncodedItem{}) {
 		t.Fatal("expected handover channel to not accept item")
 	}
 }
 
 func TestHandoverTryGet(t *testing.T) {
-	handover := NewHandoverChannel()
-	if _, ok := handover.TryGet(); ok {
+	handover := newHandoverChannel()
+	if _, ok := handover.tryGet(); ok {
 		t.Fatal("expected handover channel to not be open")
 	}
 
-	if !handover.TryOpen(1) {
+	if !handover.tryOpen(1) {
 		t.Fatal("expected handover channel to be opened")
 	}
 
-	if _, ok := handover.TryGet(); ok {
+	if _, ok := handover.tryGet(); ok {
 		t.Fatal("expected handover channel to not have any items")
 	}
 
-	if !handover.TryPut(&handoverEncodedItem{}) {
+	if !handover.tryPut(&handoverEncodedItem{}) {
 		t.Fatal("expected handover channel to accept item")
 	}
 
-	if _, ok := handover.TryGet(); !ok {
+	if _, ok := handover.tryGet(); !ok {
 		t.Fatal("expected handover channel to have item")
 	}
 
-	if _, ok := handover.TryGet(); ok {
+	if _, ok := handover.tryGet(); ok {
 		t.Fatal("expected handover channel to not have any items")
 	}
 }

--- a/internal/pkg/queue/queue.go
+++ b/internal/pkg/queue/queue.go
@@ -30,7 +30,8 @@ type PersistentGroupedQueue struct {
 	currentHost     *atomic.Uint64
 	mutex           sync.RWMutex
 
-	Handover *HandoverChannel
+	handover               *HandoverChannel
+	handoverCircuitBreaker *utils.TAtomBool
 
 	closed    *utils.TAtomBool
 	finishing *utils.TAtomBool
@@ -78,7 +79,8 @@ func NewPersistentGroupedQueue(queueDirPath string) (*PersistentGroupedQueue, er
 		closed:    new(utils.TAtomBool),
 		finishing: new(utils.TAtomBool),
 
-		Handover: NewHandoverChannel(),
+		handover:               NewHandoverChannel(),
+		handoverCircuitBreaker: new(utils.TAtomBool),
 
 		queueDirPath:    queueDirPath,
 		queueFile:       file,

--- a/internal/pkg/queue/queue.go
+++ b/internal/pkg/queue/queue.go
@@ -32,6 +32,8 @@ type PersistentGroupedQueue struct {
 
 	handover               *HandoverChannel
 	handoverCircuitBreaker *utils.TAtomBool
+	handoverMutex          sync.Mutex
+	handoverCount          *atomic.Uint64
 
 	closed    *utils.TAtomBool
 	finishing *utils.TAtomBool
@@ -81,6 +83,7 @@ func NewPersistentGroupedQueue(queueDirPath string) (*PersistentGroupedQueue, er
 
 		handover:               NewHandoverChannel(),
 		handoverCircuitBreaker: new(utils.TAtomBool),
+		handoverCount:          new(atomic.Uint64),
 
 		queueDirPath:    queueDirPath,
 		queueFile:       file,

--- a/internal/pkg/queue/queue.go
+++ b/internal/pkg/queue/queue.go
@@ -30,10 +30,11 @@ type PersistentGroupedQueue struct {
 	currentHost     *atomic.Uint64
 	mutex           sync.RWMutex
 
-	handover               *HandoverChannel
-	handoverCircuitBreaker *utils.TAtomBool
-	handoverMutex          sync.Mutex
-	handoverCount          *atomic.Uint64
+	useHandover   bool
+	handover      *handoverChannel
+	HandoverOpen  *utils.TAtomBool
+	handoverMutex sync.Mutex
+	handoverCount *atomic.Uint64
 
 	closed    *utils.TAtomBool
 	finishing *utils.TAtomBool
@@ -53,7 +54,7 @@ type Item struct {
 	Redirect        uint64
 }
 
-func NewPersistentGroupedQueue(queueDirPath string) (*PersistentGroupedQueue, error) {
+func NewPersistentGroupedQueue(queueDirPath string, useHandover bool) (*PersistentGroupedQueue, error) {
 	err := os.MkdirAll(queueDirPath, 0755)
 	if err != nil {
 		return nil, err
@@ -81,9 +82,9 @@ func NewPersistentGroupedQueue(queueDirPath string) (*PersistentGroupedQueue, er
 		closed:    new(utils.TAtomBool),
 		finishing: new(utils.TAtomBool),
 
-		handover:               NewHandoverChannel(),
-		handoverCircuitBreaker: new(utils.TAtomBool),
-		handoverCount:          new(atomic.Uint64),
+		useHandover:   useHandover,
+		HandoverOpen:  new(utils.TAtomBool),
+		handoverCount: new(atomic.Uint64),
 
 		queueDirPath:    queueDirPath,
 		queueFile:       file,
@@ -105,6 +106,13 @@ func NewPersistentGroupedQueue(queueDirPath string) (*PersistentGroupedQueue, er
 	q.closed.Set(false)
 	q.finishing.Set(false)
 	q.currentHost.Store(0)
+
+	// Handover
+	q.HandoverOpen.Set(false)
+	q.handoverCount.Store(0)
+	if useHandover {
+		q.handover = newHandoverChannel()
+	}
 
 	// Loading stats from the disk means deleting the file from disk after having read it
 	if err = q.loadStatsFromFile(path.Join(q.queueDirPath, "queue.stats")); err != nil {

--- a/internal/pkg/queue/queue_test.go
+++ b/internal/pkg/queue/queue_test.go
@@ -19,7 +19,7 @@ func TestNewPersistentGroupedQueue(t *testing.T) {
 
 	queuePath := path.Join(tempDir, "test_queue")
 
-	q, err := NewPersistentGroupedQueue(queuePath)
+	q, err := NewPersistentGroupedQueue(queuePath, false)
 	if err != nil {
 		t.Fatalf("Failed to create new queue: %v", err)
 	}
@@ -61,7 +61,7 @@ func TestPersistentGroupedQueue_Close(t *testing.T) {
 
 	queuePath := path.Join(tempDir, "test_queue")
 
-	q, err := NewPersistentGroupedQueue(queuePath)
+	q, err := NewPersistentGroupedQueue(queuePath, false)
 	if err != nil {
 		t.Fatalf("Failed to create new queue: %v", err)
 	}
@@ -110,7 +110,7 @@ func TestLargeScaleEnqueueDequeue(t *testing.T) {
 
 	queuePath := path.Join(tempDir, "test_queue")
 
-	q, err := NewPersistentGroupedQueue(queuePath)
+	q, err := NewPersistentGroupedQueue(queuePath, false)
 	if err != nil {
 		t.Fatalf("Failed to create new queue: %v", err)
 	}
@@ -182,7 +182,7 @@ func TestParallelQueueBehavior(t *testing.T) {
 	}
 	defer os.RemoveAll(queueDir)
 
-	queue, err := NewPersistentGroupedQueue(queueDir)
+	queue, err := NewPersistentGroupedQueue(queueDir, false)
 	if err != nil {
 		t.Fatalf("Failed to create queue: %v", err)
 	}
@@ -334,7 +334,7 @@ Notes:
 
 		queuePath := path.Join(tempDir, "test_queue")
 
-		q, err := NewPersistentGroupedQueue(queuePath)
+		q, err := NewPersistentGroupedQueue(queuePath, false)
 		if err != nil {
 			b.Fatalf("Failed to create new queue: %v", err)
 		}
@@ -430,7 +430,7 @@ Notes:
 
 		queuePath := path.Join(tempDir, "test_queue")
 
-		q, err := NewPersistentGroupedQueue(queuePath)
+		q, err := NewPersistentGroupedQueue(queuePath, false)
 		if err != nil {
 			b.Fatalf("Failed to create new queue: %v", err)
 		}
@@ -517,7 +517,7 @@ func TestQueueEmptyBool(t *testing.T) {
 	}
 	defer os.RemoveAll(queueDir)
 
-	queue, err := NewPersistentGroupedQueue(queueDir)
+	queue, err := NewPersistentGroupedQueue(queueDir, false)
 	if err != nil {
 		t.Fatalf("Failed to create queue: %v", err)
 	}

--- a/internal/pkg/queue/stats.go
+++ b/internal/pkg/queue/stats.go
@@ -83,7 +83,7 @@ func (q *PersistentGroupedQueue) genStats() {
 	}
 
 	// Calculate handover success get count
-	q.stats.HandoverSuccessGetCount = q.handover.count.Load()
+	q.stats.HandoverSuccessGetCount = q.handoverCount.Load()
 }
 
 func (q *PersistentGroupedQueue) loadStatsFromFile(path string) error {

--- a/internal/pkg/queue/stats.go
+++ b/internal/pkg/queue/stats.go
@@ -83,7 +83,7 @@ func (q *PersistentGroupedQueue) genStats() {
 	}
 
 	// Calculate handover success get count
-	q.stats.HandoverSuccessGetCount = q.Handover.count.Load()
+	q.stats.HandoverSuccessGetCount = q.handover.count.Load()
 }
 
 func (q *PersistentGroupedQueue) loadStatsFromFile(path string) error {

--- a/internal/pkg/queue/stats.go
+++ b/internal/pkg/queue/stats.go
@@ -83,7 +83,9 @@ func (q *PersistentGroupedQueue) genStats() {
 	}
 
 	// Calculate handover success get count
-	q.stats.HandoverSuccessGetCount = q.handoverCount.Load()
+	if q.useHandover {
+		q.stats.HandoverSuccessGetCount = q.handoverCount.Load()
+	}
 }
 
 func (q *PersistentGroupedQueue) loadStatsFromFile(path string) error {


### PR DESCRIPTION
Add :
- make handover optional
- added lastAction on API worker state to troubleshoot
- made the default HQ batches smaller
- made handover hold the whole batch before enqueuing on disk
- handover now has an automatic closing mechanism that adapts to activity so the handover get closed and drained on disk if no workers need it