### PR TITLE
Reuse free space from popped items

### DIFF
--- a/internal/pkg/queue/index/index.go
+++ b/internal/pkg/queue/index/index.go
@@ -8,7 +8,8 @@ import (
 
 type Index struct {
 	sync.Mutex
-	index        map[string][]*blob
+	index map[string][]*blob
+
 	orderedHosts []string
 }
 


### PR DESCRIPTION
The goal of this PR is to drastically slow down the growth of the queue by reusing disk space from popped items.
This `freeSpace` index will use a lock-free size-specific slot array _aka_ LSSA for common item sizes (to be determined via existing indexes analysis) and a stratified list for uncommon free space sizes. Also thinking of a defragmentation algorithm  ̶a̶n̶d̶ ̶a̶ ̶w̶a̶y̶ ̶t̶o̶ ̶s̶t̶o̶r̶e̶ ̶f̶r̶e̶e̶S̶p̶a̶c̶e̶ ̶i̶n̶d̶e̶x̶ ̶o̶p̶e̶r̶a̶t̶i̶o̶n̶s̶ ̶i̶n̶t̶o̶ ̶t̶h̶e̶ ̶W̶A̶L̶.̶ ̶ <- the `freeSpace` index is derived from index adds and pops...