### PR TITLE
Lock-free AwaitWALCommitted (and smoother queue?)

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -57,7 +57,7 @@ func getCMDsFlags(getCmd *cobra.Command) {
 	getCmd.PersistentFlags().Bool("random-local-ip", false, "Use random local IP for requests. (will be ignored if a proxy is set)")
 	getCmd.PersistentFlags().Int("min-space-required", 20, "Minimum space required in GB to continue the crawl.")
 	getCmd.PersistentFlags().Bool("no-handover", false, "Disable the handover mechanism that dispatch URLs via a buffer before enqueuing on disk.")
-	getCmd.PersistentFlags().Bool("ultrasafe-queue", false, "Don't use commited batch writes to the WAL and instead fsync() after each write.")
+	getCmd.PersistentFlags().Bool("ultrasafe-queue", false, "Don't use committed batch writes to the WAL and instead fsync() after each write.")
 
 	// Proxy flags
 	getCmd.PersistentFlags().String("proxy", "", "Proxy to use when requesting pages.")

--- a/internal/pkg/queue/index/manager.go
+++ b/internal/pkg/queue/index/manager.go
@@ -174,6 +174,7 @@ func (im *IndexManager) walCommitsSyncer() {
 	defer im.walSyncerRunning.Store(false)
 	defer close(im.walStopChan)
 
+	im.logger.Info("walCommitsSyncer started")
 	lastTrySyncDuration := time.Duration(0)
 	stopping := false
 	for {
@@ -188,7 +189,7 @@ func (im *IndexManager) walCommitsSyncer() {
 		default:
 		}
 
-		im.logger.Debug("walCommitsSyncer sleeping", "WalWait", im.WalWait, "lastTrySyncDuration", lastTrySyncDuration)
+		// im.logger.Debug("walCommitsSyncer sleeping", "WalWait", im.WalWait, "lastTrySyncDuration", lastTrySyncDuration)
 		time.Sleep(im.WalWait)
 
 		start := time.Now()

--- a/internal/pkg/queue/index/manager.go
+++ b/internal/pkg/queue/index/manager.go
@@ -47,13 +47,13 @@ type IndexManager struct {
 	walDecoder *gob.Decoder
 
 	// WAL commit
-	useCommit   bool
-	walCommit   *atomic.Uint64 // Flying in memory commit id
-	walCommited *atomic.Uint64 // Synced to disk commit id
-	// Number of listeners waiting for walCommitedNotify.
+	useCommit    bool
+	walCommit    *atomic.Uint64 // Flying in memory commit id
+	walCommitted *atomic.Uint64 // Synced to disk commit id
+	// Number of listeners waiting for walCommittedNotify.
 	// It must be accurate, otherwise walNotifyListeners will be blocked
 	walNotifyListeners *atomic.Int64
-	walCommitedNotify  chan uint64   // receives the commited id from walCommitsSyncer
+	walCommittedNotify chan uint64   // receives the committed id from walCommitsSyncer
 	walSyncerRunning   atomic.Bool   // used to prevent multiple walCommitsSyncer running,
 	walStopChan        chan struct{} // Syncer will close this channel after stopping
 	WalIoPercent       int           // [1, 100] limit max io percentage for WAL sync
@@ -105,9 +105,9 @@ func NewIndexManager(walPath, indexPath, queueDirPath string, useCommit bool) (*
 	// Init WAL commit if enabled
 	if useCommit {
 		im.walCommit = new(atomic.Uint64)
-		im.walCommited = new(atomic.Uint64)
+		im.walCommitted = new(atomic.Uint64)
 		im.walNotifyListeners = new(atomic.Int64)
-		im.walCommitedNotify = make(chan uint64)
+		im.walCommittedNotify = make(chan uint64)
 		im.WalIoPercent = 10
 		im.WalMinInterval = 10 * time.Millisecond
 		im.walStopChan = make(chan struct{})
@@ -219,27 +219,27 @@ func (im *IndexManager) walCommitsSyncer() {
 			im.logger.Error("failed to sync WAL, retrying", "error", err)
 			continue // we may infinitely retry, but it's better than losing data
 		}
-		commited := flyingCommit
+		committed := flyingCommit
 
-		im.walCommited.Store(commited)
+		im.walCommitted.Store(committed)
 
 		// Clear notify channel before sending, just in case.
 		// should never happen if listeners number is accurate.
-		for len(im.walCommitedNotify) > 0 {
-			<-im.walCommitedNotify
-			im.logger.Warn("unconsumed commited id in walCommitedNotify")
+		for len(im.walCommittedNotify) > 0 {
+			<-im.walCommittedNotify
+			im.logger.Warn("unconsumed committed id in walCommittedNotify")
 		}
 
-		// Send the commited id to all listeners
+		// Send the committed id to all listeners
 		listeners := im.walNotifyListeners.Load()
 		for i := int64(0); i < listeners; i++ {
-			im.walCommitedNotify <- commited
+			im.walCommittedNotify <- committed
 		}
 	}
 }
 
-func (im *IndexManager) IsWALCommited(commit uint64) bool {
-	return im.walCommited.Load() >= commit
+func (im *IndexManager) IsWALCommitted(commit uint64) bool {
+	return im.walCommitted.Load() >= commit
 }
 
 // increments the WAL commit counter and returns the new commit ID.
@@ -247,23 +247,23 @@ func (im *IndexManager) WALCommit() uint64 {
 	return im.walCommit.Add(1)
 }
 
-// AwaitWALCommitted blocks until the given commit ID is commited to disk by Syncer.
+// AwaitWALCommitted blocks until the given commit ID is committed to disk by Syncer.
 // DO NOT call this function with im.Lock() held, it will deadlock.
 func (im *IndexManager) AwaitWALCommitted(commit uint64) {
 	if commit == 0 {
-		im.logger.Warn("AwaitWALCommited called with commit 0")
+		im.logger.Warn("AwaitWALCommitted called with commit 0")
 		return
 	}
 	if !im.walSyncerRunning.Load() {
-		im.logger.Warn("AwaitWALCommited called without Syncer running, beaware of hanging")
+		im.logger.Warn("AwaitWALCommitted called without Syncer running, beaware of hanging")
 	}
-	if im.IsWALCommited(commit) {
+	if im.IsWALCommitted(commit) {
 		return
 	}
 
 	for {
 		im.walNotifyListeners.Add(1)
-		idFromChan := <-im.walCommitedNotify
+		idFromChan := <-im.walCommittedNotify
 		im.walNotifyListeners.Add(-1)
 
 		if idFromChan >= commit {

--- a/internal/pkg/queue/index/manager_test.go
+++ b/internal/pkg/queue/index/manager_test.go
@@ -46,8 +46,7 @@ func provideTestIndexManager(t *testing.T, withSyncer bool) (*IndexManager, stri
 		im.walCommit = new(atomic.Uint64)
 		im.walCommitted = new(atomic.Uint64)
 		im.walNotifyListeners = new(atomic.Int64)
-		im.WalIoPercent = 100
-		im.WalMinInterval = time.Duration(0)
+		im.WalWait = time.Duration(time.Millisecond)
 
 		go im.walCommitsSyncer()
 		for !im.walSyncerRunning.Load() {
@@ -92,8 +91,7 @@ func provideBenchmarkIndexManager(b *testing.B, withSyncer bool) (*IndexManager,
 		im.walCommit = new(atomic.Uint64)
 		im.walCommitted = new(atomic.Uint64)
 		im.walNotifyListeners = new(atomic.Int64)
-		im.WalIoPercent = 100
-		im.WalMinInterval = time.Duration(0)
+		im.WalWait = time.Duration(time.Millisecond)
 
 		go im.walCommitsSyncer()
 		for !im.walSyncerRunning.Load() {

--- a/internal/pkg/queue/index/manager_test.go
+++ b/internal/pkg/queue/index/manager_test.go
@@ -44,7 +44,7 @@ func provideTestIndexManager(t *testing.T, withSyncer bool) (*IndexManager, stri
 	}
 	if withSyncer {
 		im.walCommit = new(atomic.Uint64)
-		im.walCommited = new(atomic.Uint64)
+		im.walCommitted = new(atomic.Uint64)
 		im.walNotifyListeners = new(atomic.Int64)
 		im.WalIoPercent = 100
 		im.WalMinInterval = time.Duration(0)
@@ -90,7 +90,7 @@ func provideBenchmarkIndexManager(b *testing.B, withSyncer bool) (*IndexManager,
 	}
 	if withSyncer {
 		im.walCommit = new(atomic.Uint64)
-		im.walCommited = new(atomic.Uint64)
+		im.walCommitted = new(atomic.Uint64)
 		im.walNotifyListeners = new(atomic.Int64)
 		im.WalIoPercent = 100
 		im.WalMinInterval = time.Duration(0)

--- a/internal/pkg/queue/index/recovery_test.go
+++ b/internal/pkg/queue/index/recovery_test.go
@@ -153,7 +153,6 @@ func Test_RecoveryAfterOneIndexDumpAndWALNotEmpty(t *testing.T) {
 		lastDumpTime: time.Now(),
 		useCommit:    false,
 	}
-
 	// Logger
 	logger, _ := log.DefaultOrStored()
 	im.logger = logger

--- a/internal/pkg/queue/queue_test.go
+++ b/internal/pkg/queue/queue_test.go
@@ -111,8 +111,7 @@ func TestLargeScaleEnqueueDequeue(t *testing.T) {
 	queuePath := path.Join(tempDir, "test_queue")
 
 	q, err := NewPersistentGroupedQueue(queuePath, false, false)
-	q.index.WalIoPercent = 100
-	q.index.WalMinInterval = time.Duration(0)
+	q.index.WalWait = time.Duration(time.Millisecond)
 	if err != nil {
 		t.Fatalf("Failed to create new queue: %v", err)
 	}
@@ -185,8 +184,7 @@ func TestParallelQueueBehavior(t *testing.T) {
 	defer os.RemoveAll(queueDir)
 
 	queue, err := NewPersistentGroupedQueue(queueDir, false, false)
-	queue.index.WalIoPercent = 100
-	queue.index.WalMinInterval = time.Duration(0)
+	queue.index.WalWait = time.Duration(time.Millisecond)
 	if err != nil {
 		t.Fatalf("Failed to create queue: %v", err)
 	}
@@ -342,8 +340,7 @@ Notes:
 		if err != nil {
 			b.Fatalf("Failed to create new queue: %v", err)
 		}
-		q.index.WalIoPercent = 100
-		q.index.WalMinInterval = time.Duration(0)
+		q.index.WalWait = time.Duration(time.Millisecond)
 		defer q.Close()
 
 		numItems := 50000


### PR DESCRIPTION
- Make batchEnqueueUntilCommitted release the mutex lock before executing AwaitWALCommitted so that multiple batchEnqueueUntilCommitted can be executed concurrently with/like enqueueUntilCommitted.
- try to use a fixed fsync interval (currently hardcoded 100ms) to achieve smoother queue performance.