### PR TITLE
Implement XML parsing using stdlib

### DIFF
--- a/internal/pkg/crawl/extractor/xml.go
+++ b/internal/pkg/crawl/extractor/xml.go
@@ -43,6 +43,14 @@ func XML(resp *http.Response) (URLs []*url.URL, sitemap bool, err error) {
 		case xml.StartElement:
 			startElement = tok
 			currentNode = &LeafNode{Path: startElement.Name.Local}
+			for _, attr := range tok.Attr {
+				if strings.HasPrefix(attr.Value, "http") {
+					parsedURL, err := url.Parse(attr.Value)
+					if err == nil {
+						URLs = append(URLs, parsedURL)
+					}
+				}
+			}
 		case xml.EndElement:
 			if currentNode != nil {
 				leafNodes = append(leafNodes, *currentNode)

--- a/internal/pkg/crawl/extractor/xml.go
+++ b/internal/pkg/crawl/extractor/xml.go
@@ -1,6 +1,7 @@
 package extractor
 
 import (
+	"bytes"
 	"encoding/xml"
 	"io"
 	"net/http"
@@ -23,7 +24,7 @@ func XML(resp *http.Response) (URLs []*url.URL, sitemap bool, err error) {
 		sitemap = true
 	}
 
-	reader := strings.NewReader(string(xmlBody))
+	reader := bytes.NewReader(xmlBody)
 	decoder := xml.NewDecoder(reader)
 
 	var (

--- a/internal/pkg/crawl/extractor/xml.go
+++ b/internal/pkg/crawl/extractor/xml.go
@@ -23,12 +23,24 @@ func XML(resp *http.Response) (URLs []*url.URL, sitemap bool, err error) {
 		sitemap = true
 	}
 
-	decoder := xml.NewDecoder(strings.NewReader(string(xmlBody)))
+	reader := strings.NewReader(string(xmlBody))
+	decoder := xml.NewDecoder(reader)
+
 	var (
 		startElement xml.StartElement
 		currentNode  *LeafNode
 		leafNodes    []LeafNode
 	)
+
+	// try to decode one token to see if stream is open
+	_, err = decoder.Token()
+	if err != nil {
+		return nil, sitemap, err
+	}
+
+	// seek back to 0 if we are still here
+	reader.Seek(0, 0)
+	decoder = xml.NewDecoder(reader)
 
 	for {
 		tok, err := decoder.Token()


### PR DESCRIPTION
This PR replaces `github.com/clbanning/mxj/v2` and uses `encoding/xml` `xml.Decoder` to parse xml and extract urls within.

EDIT: All tests pass now. The PR is complete

Co-Author: @yzqzss 

<strike>

Only two tests fail, I am trying to fix those

<details>
<summary>Tests</summary>

```fish
go: downloading git.archive.org/wb/gocrawlhq v1.2.13
internal/pkg/crawl/config.go:11:2: unrecognized import path "git.archive.org/wb/gocrawlhq": https fetch: Get "https://git.archive.org/wb/gocrawlhq?go-get=1": dial tcp 207.241.235.124:443: i/o timeout
=== RUN   TestJSON
=== RUN   TestJSON/Valid_JSON_with_URLs
=== RUN   TestJSON/Invalid_JSON
=== RUN   TestJSON/JSON_with_no_URLs
=== RUN   TestJSON/JSON_with_URLs_in_various_fields
=== RUN   TestJSON/JSON_with_array_of_URLs
--- PASS: TestJSON (0.00s)
    --- PASS: TestJSON/Valid_JSON_with_URLs (0.00s)
    --- PASS: TestJSON/Invalid_JSON (0.00s)
    --- PASS: TestJSON/JSON_with_no_URLs (0.00s)
    --- PASS: TestJSON/JSON_with_URLs_in_various_fields (0.00s)
    --- PASS: TestJSON/JSON_with_array_of_URLs (0.00s)
=== RUN   TestXML
=== RUN   TestXML/Valid_XML_with_URLs
=== RUN   TestXML/Empty_XML
=== RUN   TestXML/Invalid_XML
=== RUN   TestXML/XML_with_invalid_URL
=== RUN   TestXML/Huge_sitemap
    xml_test.go:88: XML() gotURLs count = 10000, want 100002
--- FAIL: TestXML (0.76s)
    --- PASS: TestXML/Valid_XML_with_URLs (0.00s)
    --- PASS: TestXML/Empty_XML (0.00s)
    --- PASS: TestXML/Invalid_XML (0.00s)
    --- PASS: TestXML/XML_with_invalid_URL (0.00s)
    --- FAIL: TestXML/Huge_sitemap (0.66s)
=== RUN   TestXMLBodyReadError
    xml_test.go:127: XML() expected error, got nil
--- FAIL: TestXMLBodyReadError (0.00s)
FAIL
FAIL	github.com/internetarchive/Zeno/internal/pkg/crawl/extractor	0.780s
FAIL
```
</details>

</strike>

Closes #84 