### PR TITLE
Better xml parsing

### DIFF
--- a/internal/pkg/crawl/capture.go
+++ b/internal/pkg/crawl/capture.go
@@ -470,7 +470,8 @@ func (c *Crawl) Capture(item *queue.Item) error {
 			URLsFromXML, isSitemap, err := extractor.XML(resp, false)
 			if err != nil {
 				c.Log.WithFields(c.genLogFields(err, item.URL, nil)).Error("unable to extract URLs from XML")
-			} else {
+			}
+			if len(URLsFromXML) > 0 {
 				if isSitemap {
 					outlinks = append(outlinks, URLsFromXML...)
 				} else {

--- a/internal/pkg/crawl/capture.go
+++ b/internal/pkg/crawl/capture.go
@@ -467,7 +467,7 @@ func (c *Crawl) Capture(item *queue.Item) error {
 
 			outlinks = append(outlinks, URLsFromS3...)
 		} else {
-			URLsFromXML, isSitemap, err := extractor.XML(resp)
+			URLsFromXML, isSitemap, err := extractor.XML(resp, false)
 			if err != nil {
 				c.Log.WithFields(c.genLogFields(err, item.URL, nil)).Error("unable to extract URLs from XML")
 			} else {

--- a/internal/pkg/crawl/extractor/xml.go
+++ b/internal/pkg/crawl/extractor/xml.go
@@ -36,8 +36,10 @@ func XML(resp *http.Response, strict bool) (URLs []*url.URL, sitemap bool, err e
 			// normal EOF
 			break
 		}
+
 		if err != nil {
-			return nil, sitemap, err
+			// return URLs we got so far when error occurs
+			return URLs, sitemap, err
 		}
 
 		switch tok := tok.(type) {

--- a/internal/pkg/crawl/extractor/xml.go
+++ b/internal/pkg/crawl/extractor/xml.go
@@ -9,13 +9,15 @@ import (
 	"strings"
 )
 
+var sitemapMarker = []byte("sitemaps.org/schemas/sitemap/")
+
 func XML(resp *http.Response) (URLs []*url.URL, sitemap bool, err error) {
 	xmlBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, sitemap, err
 	}
 
-	if strings.Contains(string(xmlBody), "sitemaps.org/schemas/sitemap/") {
+	if bytes.Contains(xmlBody, sitemapMarker) {
 		sitemap = true
 	}
 
@@ -52,7 +54,7 @@ func XML(resp *http.Response) (URLs []*url.URL, sitemap bool, err error) {
 				}
 			}
 		case xml.CharData:
-			if strings.HasPrefix(string(tok), "http") {
+			if bytes.HasPrefix(tok, []byte("http")) {
 				parsedURL, err := url.Parse(string(tok))
 				if err == nil {
 					URLs = append(URLs, parsedURL)


### PR DESCRIPTION
~~This PR is based on #155~~

---

- Introduce lax parsing mode, so that we can get URLs from unbalanced or malformed XML.
- Return parsed `URLs` instead of `nil` when an error occurs.
- Replace `TestXMLBodyReadError` test with `TestXMLBodySyntaxEOFError`.