### PR TITLE
Reduce memory usage by using spooled temp file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/internetarchive/Zeno
 go 1.23.3
 
 require (
-	github.com/CorentinB/warc v0.8.57
+	github.com/CorentinB/warc v0.8.60
 	github.com/PuerkitoBio/goquery v1.10.0
 	github.com/ada-url/goada v0.0.0-20240402045241-5e45a5777313
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/CorentinB/warc v0.8.57 h1:HaX3dD90WEVghi1TlELzE+Murshi/mtk5jNjAnBmGto=
-github.com/CorentinB/warc v0.8.57/go.mod h1:NblONkMtoBB4TIigew6F6vakzu0z3YQTKNFS8U2FIn8=
+github.com/CorentinB/warc v0.8.60 h1:uZQ0CIcuHkWS2XOCCn35GFVg/DNlal0oyVIiZMuAh0s=
+github.com/CorentinB/warc v0.8.60/go.mod h1:Vxe1u5b3UBLJz6Kxxy6Wndcr3kirZNQB4+nDRjEBZmQ=
 github.com/PuerkitoBio/goquery v1.10.0 h1:6fiXdLuUvYs2OJSvNRqlNPoBm6YABE226xrbavY5Wv4=
 github.com/PuerkitoBio/goquery v1.10.0/go.mod h1:TjZZl68Q3eGHNBA8CWaxAN7rOU1EbDz3CWuolcO5Yu4=
 github.com/ada-url/goada v0.0.0-20240402045241-5e45a5777313 h1:jdPBTZ3nZwBBZzz5SCFUMcTxoZr8t9ogwdvD3P27f/E=

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/internetarchive/Zeno/internal/pkg/utils"
+	"github.com/internetarchive/Zeno/pkg/models"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
@@ -219,6 +220,7 @@ func GenerateCrawlConfig() error {
 
 	if config.WARCTempDir == "" {
 		config.WARCTempDir = path.Join(config.JobPath, "temp")
+		models.PROCESS_BODY_TEMP_DIR = config.WARCTempDir
 	}
 
 	if config.UserAgent == "" {

--- a/internal/pkg/postprocessor/assets.go
+++ b/internal/pkg/postprocessor/assets.go
@@ -53,7 +53,7 @@ func extractAssets(item *models.Item) (assets []*models.URL, err error) {
 		logger.Debug("no extractor used for page", "content-type", contentType, "item", item.GetShortID())
 	}
 
-	logger.Info("extracted assets", "item", item.GetShortID(), "assets", len(assets))
+	logger.Debug("extracted assets", "item", item.GetShortID(), "assets", len(assets))
 
 	return
 }

--- a/internal/pkg/postprocessor/extractor/base.go
+++ b/internal/pkg/postprocessor/extractor/base.go
@@ -1,12 +1,12 @@
-package postprocessor
+package extractor
 
 import (
 	"github.com/PuerkitoBio/goquery"
 	"github.com/internetarchive/Zeno/pkg/models"
 )
 
-func scrapeBaseTag(item *models.Item) {
-	item.GetURL().GetDocument().Find("base").Each(func(index int, base *goquery.Selection) {
+func extractBaseTag(item *models.Item, doc *goquery.Document) {
+	doc.Find("base").Each(func(index int, base *goquery.Selection) {
 		href, exists := base.Attr("href")
 		if exists {
 			item.SetBase(href)

--- a/internal/pkg/postprocessor/extractor/html.go
+++ b/internal/pkg/postprocessor/extractor/html.go
@@ -36,6 +36,8 @@ func HTMLOutlinks(item *models.Item) (outlinks []*models.URL, err error) {
 		return nil, err
 	}
 
+	item.GetURL().RewindBody()
+
 	// Extract the base tag if it exists
 	extractBaseTag(item, document)
 
@@ -84,8 +86,6 @@ func HTMLOutlinks(item *models.Item) (outlinks []*models.URL, err error) {
 }
 
 func HTMLAssets(item *models.Item) (assets []*models.URL, err error) {
-	defer item.GetURL().RewindBody()
-
 	logger := log.NewFieldedLogger(&log.Fields{
 		"component": "postprocessor.extractor.HTMLAssets",
 	})
@@ -97,6 +97,8 @@ func HTMLAssets(item *models.Item) (assets []*models.URL, err error) {
 	if err != nil {
 		return nil, err
 	}
+
+	item.GetURL().RewindBody()
 
 	// Extract the base tag if it exists
 	extractBaseTag(item, document)

--- a/internal/pkg/postprocessor/extractor/html.go
+++ b/internal/pkg/postprocessor/extractor/html.go
@@ -30,13 +30,11 @@ func HTMLOutlinks(item *models.Item) (outlinks []*models.URL, err error) {
 
 	var rawOutlinks []string
 
-	// Create document from the body
-	document, err := goquery.NewDocumentFromReader(item.GetURL().GetBody())
+	// Retrieve (potentially creates it) the document from the body
+	document, err := item.GetURL().GetDocument()
 	if err != nil {
 		return nil, err
 	}
-
-	item.GetURL().RewindBody()
 
 	// Extract the base tag if it exists
 	extractBaseTag(item, document)
@@ -92,13 +90,11 @@ func HTMLAssets(item *models.Item) (assets []*models.URL, err error) {
 
 	var rawAssets []string
 
-	// Create document from the body
-	document, err := goquery.NewDocumentFromReader(item.GetURL().GetBody())
+	// Retrieve (potentially creates it) the document from the body
+	document, err := item.GetURL().GetDocument()
 	if err != nil {
 		return nil, err
 	}
-
-	item.GetURL().RewindBody()
 
 	// Extract the base tag if it exists
 	extractBaseTag(item, document)

--- a/internal/pkg/postprocessor/extractor/html.go
+++ b/internal/pkg/postprocessor/extractor/html.go
@@ -36,8 +36,6 @@ func HTMLOutlinks(item *models.Item) (outlinks []*models.URL, err error) {
 		return nil, err
 	}
 
-	item.GetURL().RewindBody()
-
 	// Extract the base tag if it exists
 	extractBaseTag(item, document)
 
@@ -99,8 +97,6 @@ func HTMLAssets(item *models.Item) (assets []*models.URL, err error) {
 	if err != nil {
 		return nil, err
 	}
-
-	item.GetURL().RewindBody()
 
 	// Extract the base tag if it exists
 	extractBaseTag(item, document)

--- a/internal/pkg/postprocessor/outlinks.go
+++ b/internal/pkg/postprocessor/outlinks.go
@@ -33,7 +33,7 @@ func extractOutlinks(item *models.Item) (outlinks []*models.URL, err error) {
 			return outlinks, err
 		}
 	case extractor.IsHTML(item.GetURL()):
-		outlinks, err := extractor.HTMLOutlinks(item.GetURL())
+		outlinks, err := extractor.HTMLOutlinks(item)
 		if err != nil {
 			logger.Error("unable to extract outlinks", "err", err.Error(), "item", item.GetShortID())
 			return outlinks, err

--- a/internal/pkg/postprocessor/outlinks.go
+++ b/internal/pkg/postprocessor/outlinks.go
@@ -18,6 +18,11 @@ func extractOutlinks(item *models.Item) (outlinks []*models.URL, err error) {
 		})
 	)
 
+	if item.GetURL().GetBody() == nil {
+		logger.Error("no body to extract outlinks from", "url", item.GetURL().String(), "item", item.GetShortID())
+		return
+	}
+
 	// Run specific extractors
 	switch {
 	case extractor.IsS3(item.GetURL()):

--- a/internal/pkg/postprocessor/postprocess.go
+++ b/internal/pkg/postprocessor/postprocess.go
@@ -78,12 +78,12 @@ func postprocessItem(item, seed *models.Item) (outlinks []*models.Item) {
 
 	if item.GetURL().GetResponse() != nil && item.GetURL().GetResponse().StatusCode == 200 {
 		// If the URL is a seed, scrape the base tag
-		if (item.IsSeed() || item.IsRedirection()) && item.GetURL().GetDocument() != nil {
-			scrapeBaseTag(item)
-		}
+		// if (item.IsSeed() || item.IsRedirection()) && item.GetURL().GetDocument() != nil {
+		// 	scrapeBaseTag(item)
+		// }
 
 		// Extract assets from the page
-		if !config.Get().DisableAssetsCapture && item.GetURL().GetDocument() != nil {
+		if !config.Get().DisableAssetsCapture {
 			assets, err := extractAssets(item)
 			if err != nil {
 				logger.Error("unable to extract assets", "err", err.Error(), "item", item.GetShortID())

--- a/internal/pkg/postprocessor/postprocess.go
+++ b/internal/pkg/postprocessor/postprocess.go
@@ -116,6 +116,9 @@ func postprocessItem(item, seed *models.Item) (outlinks []*models.Item) {
 		}
 	}
 
+	// Make sure the goquery document's memory can be freed
+	item.GetURL().SetDocument(nil)
+
 	if item.GetStatus() != models.ItemGotChildren && item.GetStatus() != models.ItemGotRedirected {
 		item.SetStatus(models.ItemCompleted)
 	}

--- a/internal/pkg/postprocessor/postprocess.go
+++ b/internal/pkg/postprocessor/postprocess.go
@@ -77,13 +77,8 @@ func postprocessItem(item, seed *models.Item) (outlinks []*models.Item) {
 	}
 
 	if item.GetURL().GetResponse() != nil && item.GetURL().GetResponse().StatusCode == 200 {
-		// If the URL is a seed, scrape the base tag
-		// if (item.IsSeed() || item.IsRedirection()) && item.GetURL().GetDocument() != nil {
-		// 	scrapeBaseTag(item)
-		// }
-
 		// Extract assets from the page
-		if !config.Get().DisableAssetsCapture {
+		if !config.Get().DisableAssetsCapture && item.GetURL().GetBody() != nil {
 			assets, err := extractAssets(item)
 			if err != nil {
 				logger.Error("unable to extract assets", "err", err.Error(), "item", item.GetShortID())
@@ -101,8 +96,7 @@ func postprocessItem(item, seed *models.Item) (outlinks []*models.Item) {
 		}
 
 		// Extract outlinks from the page
-		if config.Get().DomainsCrawl || ((item.IsSeed() || item.IsRedirection()) && item.GetURL().GetHops() < config.Get().MaxHops) {
-			logger.Info("extracting outlinks", "item", item.GetShortID())
+		if (config.Get().DomainsCrawl || ((item.IsSeed() || item.IsRedirection()) && item.GetURL().GetHops() < config.Get().MaxHops)) && item.GetURL().GetBody() != nil {
 			links, err := extractOutlinks(item)
 			if err != nil {
 				logger.Error("unable to extract outlinks", "err", err.Error(), "item", item.GetShortID())

--- a/internal/pkg/postprocessor/postprocessor.go
+++ b/internal/pkg/postprocessor/postprocessor.go
@@ -150,6 +150,18 @@ func postprocess(seed *models.Item) (outlinks []*models.Item) {
 
 	for i := range items {
 		outlinks = postprocessItem(items[i], seed)
+
+		// Once the item is postprocessed, we can close the body buffer if it exists.
+		// It will release the resources and delete the temporary file (if any).
+		if items[i].GetURL().GetBody() != nil {
+			err = items[i].GetURL().GetBody().Close()
+			if err != nil {
+				logger.Error("unable to close body", "err", err.Error(), "item_id", items[i].GetShortID())
+				panic(err)
+			}
+
+			items[i].GetURL().SetBody(nil)
+		}
 	}
 
 	return

--- a/internal/pkg/preprocessor/preprocessor.go
+++ b/internal/pkg/preprocessor/preprocessor.go
@@ -163,13 +163,13 @@ func preprocess(item *models.Item) {
 
 			// Verify if the URL isn't to be excluded
 			if utils.StringContainsSliceElements(items[i].GetURL().GetParsed().Host, config.Get().ExcludeHosts) {
-				logger.Warn("URL excluded", "url", items[i].GetURL().String())
+				logger.Debug("URL excluded", "url", items[i].GetURL().String())
 				items[i].GetParent().RemoveChild(items[i])
 				continue
 			}
 
 			if utils.StringContainsSliceElements(items[i].GetURL().GetParsed().Path, config.Get().ExcludeString) {
-				logger.Warn("URL excluded", "url", items[i].GetURL().String())
+				logger.Debug("URL excluded", "url", items[i].GetURL().String())
 				items[i].GetParent().RemoveChild(items[i])
 				continue
 			}

--- a/pkg/models/url.go
+++ b/pkg/models/url.go
@@ -63,7 +63,7 @@ func (u *URL) ProcessBody() error {
 	u.mimetype = mimetype.Detect(buffer.Bytes())
 
 	// Check if the MIME type is one that we post-process
-	if u.mimetype.Parent() != nil && u.mimetype.Parent().String() == "text/plain" {
+	if (u.mimetype.Parent() != nil && u.mimetype.Parent().String() == "text/plain") || strings.Contains(u.mimetype.String(), "text/") {
 		spooledBuff := warc.NewSpooledTempFile("zeno", PROCESS_BODY_TEMP_DIR, 2000000, false)
 		_, err := io.Copy(spooledBuff, buffer)
 		if err != nil {

--- a/pkg/models/url.go
+++ b/pkg/models/url.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/CorentinB/warc"
+	"github.com/PuerkitoBio/goquery"
 	"github.com/gabriel-vasile/mimetype"
 	"golang.org/x/net/idna"
 )
@@ -30,6 +31,7 @@ type URL struct {
 	request   *http.Request
 	response  *http.Response
 	body      warc.ReadSeekCloser
+	document  *goquery.Document
 	mimetype  *mimetype.MIME
 	Hops      int // This determines the number of hops this item is the result of, a hop is a "jump" from 1 page to another page
 	Redirects int
@@ -46,6 +48,23 @@ func (u *URL) GetBody() warc.ReadSeekCloser {
 
 func (u *URL) SetBody(body warc.ReadSeekCloser) {
 	u.body = body
+}
+
+func (u *URL) GetDocument() (doc *goquery.Document, err error) {
+	if u.document == nil {
+		u.document, err = goquery.NewDocumentFromReader(u.GetBody())
+		if err != nil {
+			return nil, err
+		}
+
+		u.RewindBody()
+	}
+
+	return u.document, nil
+}
+
+func (u *URL) SetDocument(doc *goquery.Document) {
+	u.document = doc
 }
 
 func (u *URL) ProcessBody() error {

--- a/pkg/models/url.go
+++ b/pkg/models/url.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/CorentinB/warc"
-	"github.com/PuerkitoBio/goquery"
 	"github.com/gabriel-vasile/mimetype"
 	"golang.org/x/net/idna"
 )
@@ -32,7 +31,6 @@ type URL struct {
 	response  *http.Response
 	body      warc.ReadSeekCloser
 	mimetype  *mimetype.MIME
-	document  *goquery.Document
 	Hops      int // This determines the number of hops this item is the result of, a hop is a "jump" from 1 page to another page
 	Redirects int
 }
@@ -80,14 +78,6 @@ func (u *URL) ProcessBody() error {
 
 		u.SetBody(spooledBuff)
 		u.RewindBody()
-
-		// Also create the goquery document
-		u.document, err = goquery.NewDocumentFromReader(u.GetBody())
-		if err != nil {
-			return err
-		}
-
-		u.RewindBody()
 	} else {
 		// Read the rest of the body but discard it
 		_, err := io.Copy(io.Discard, u.response.Body)
@@ -101,10 +91,6 @@ func (u *URL) ProcessBody() error {
 
 func (u *URL) GetMIME() *mimetype.MIME {
 	return u.mimetype
-}
-
-func (u *URL) GetDocument() *goquery.Document {
-	return u.document
 }
 
 func (u *URL) RewindBody() {


### PR DESCRIPTION
This PR aims to implement the same mechanism that is being used for WARC writing, for the post-processing of response body. That is, when reaching a certain threshold of size (2MB right now), the response body of a request that need to be post-processed is rolled over to a file on disk.