### PR TITLE
Fix assets hops handling

### DIFF
--- a/internal/pkg/postprocessor/postprocess.go
+++ b/internal/pkg/postprocessor/postprocess.go
@@ -65,8 +65,7 @@ func postprocessItem(item, seed *models.Item) (outlinks []*models.Item) {
 	// Return if:
 	// - the item is a child and the URL has more than one hop
 	// - assets capture is disabled and domains crawl is disabled
-	// - the item is a seed and the URL has more hops than the max allowed
-	if item.IsChild() && item.GetURL().GetHops() > 1 {
+	if item.GetDepthWithoutRedirections() > 1 {
 		logger.Debug("item is child and URL has more than one hop", "item_id", item.GetShortID())
 		item.SetStatus(models.ItemCompleted)
 		return

--- a/pkg/models/item.go
+++ b/pkg/models/item.go
@@ -175,6 +175,18 @@ func (i *Item) GetDepth() int64 {
 	return i.parent.GetDepth() + 1
 }
 
+func (i *Item) GetDepthWithoutRedirections() int64 {
+	if i.seed {
+		return 0
+	}
+
+	if i.status == ItemGotRedirected {
+		return i.parent.GetDepthWithoutRedirections()
+	}
+
+	return i.parent.GetDepthWithoutRedirections() + 1
+}
+
 // GetChildren returns the children of the item
 func (i *Item) GetChildren() []*Item {
 	i.childrenMu.RLock()

--- a/pkg/models/item_test.go
+++ b/pkg/models/item_test.go
@@ -558,6 +558,72 @@ func TestItem_GetDepth(t *testing.T) {
 		})
 	}
 }
+
+func TestItem_GetDepthWithoutRedirections(t *testing.T) {
+	tests := []struct {
+		name     string
+		item     *Item
+		expected int64
+	}{
+		{
+			name:     "Seed item",
+			item:     createTestItem("root", true, nil),
+			expected: 0,
+		},
+		{
+			name: "Child item without redirections",
+			item: func() *Item {
+				root := createTestItem("root", true, nil)
+				child := createTestItem("child", false, root)
+				return child
+			}(),
+			expected: 1,
+		},
+		{
+			name: "Grandchild item without redirections",
+			item: func() *Item {
+				root := createTestItem("root", true, nil)
+				child := createTestItem("child", false, root)
+				grandchild := createTestItem("grandchild", false, child)
+				return grandchild
+			}(),
+			expected: 2,
+		},
+		{
+			name: "Child item with redirection",
+			item: func() *Item {
+				root := createTestItem("root", true, nil)
+				child := createTestItem("child", false, root)
+				child.status = ItemGotRedirected
+				grandchild := createTestItem("grandchild", false, child)
+				return grandchild
+			}(),
+			expected: 1,
+		},
+		{
+			name: "Great-grandchild item with multiple redirections",
+			item: func() *Item {
+				root := createTestItem("root", true, nil)
+				child := createTestItem("child", false, root)
+				child.status = ItemGotRedirected
+				grandchild := createTestItem("grandchild", false, child)
+				grandchild.status = ItemGotRedirected
+				greatGrandchild := createTestItem("greatGrandchild", false, grandchild)
+				return greatGrandchild
+			}(),
+			expected: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.item.GetDepthWithoutRedirections(); got != tt.expected {
+				t.Errorf("GetDepthWithoutRedirections() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
 func TestItem_GetMaxDepth(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
This PR aims to make use of tree depth instead of hops for stopping the extraction of assets. (but still allowing 2 layers of extraction)