### PR TITLE
Optimise extractBaseTag and add unit test

### DIFF
--- a/internal/pkg/postprocessor/extractor/base.go
+++ b/internal/pkg/postprocessor/extractor/base.go
@@ -6,10 +6,8 @@ import (
 )
 
 func extractBaseTag(item *models.Item, doc *goquery.Document) {
-	doc.Find("base").Each(func(index int, i *goquery.Selection) {
-		base, exists := i.Attr("href")
-		if exists {
-			item.SetBase(base)
-		}
-	})
+	base, exists := doc.Find("base").First().Attr("href")
+	if exists {
+		item.SetBase(base)
+	}
 }

--- a/internal/pkg/postprocessor/extractor/base_test.go
+++ b/internal/pkg/postprocessor/extractor/base_test.go
@@ -1,0 +1,37 @@
+package extractor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/internetarchive/Zeno/pkg/models"
+	"github.com/PuerkitoBio/goquery"
+)
+
+func TestExtractBaseTag(t *testing.T) {
+	htmlString := `
+	<!DOCTYPE html>
+	<html>
+	<head>
+		<title>Test Page</title>
+		<base href="http://example.com/something/"
+	</head>
+	<body>
+		<p>First paragraph</p>
+	</body>
+	</html>`
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(htmlString))
+	if err != nil {
+		t.Errorf("html doc loading failed %s", err)
+	}
+
+	item := models.NewItem("test", &models.URL{
+    Raw: "https://example.com/something/page.html",
+  }, "", false)
+
+	extractBaseTag(item, doc)
+
+	if item.GetBase() != "http://example.com/something/" {
+		t.Errorf("Cannot find html doc base.href")
+	}
+}


### PR DESCRIPTION
The current code looks for `base` tag but doesn't stop if it finds one. It will still search until the end of the doc.

The suggested improvement uses `doc.Find("base").First()` to get just the first element as `<base>` is used just once on the HTML doc header.

We also add a unit test.