### PR TITLE
Refactor HTMLAssets and add unit tests

### DIFF
--- a/internal/pkg/postprocessor/extractor/html_test.go
+++ b/internal/pkg/postprocessor/extractor/html_test.go
@@ -45,3 +45,72 @@ func TestHTMLOutlinks(t *testing.T) {
 		t.Errorf("We couldn't extract all HTML outlinks.")
 	}
 }
+
+// Test <audio> and <video> src extraction
+func TestHTMLAssetsAudioVideo(t *testing.T) {
+	audioVideoBody := `
+	<html>
+		<head></head>
+		<body>
+			<video src="http://f1.com"></video>
+			<p>test</p>
+			<audio src="http://f2.com"></audio>
+		</body>
+	</html>
+	`
+
+	resp := &http.Response{
+		Body: io.NopCloser(bytes.NewBufferString(audioVideoBody)),
+	}
+	newURL := &models.URL{Raw: "http://ex.com"}
+	newURL.SetResponse(resp)
+	err := archiver.ProcessBody(newURL, false, false, 0, os.TempDir())
+	if err != nil {
+		t.Errorf("ProcessBody() error = %v", err)
+	}
+	item := models.NewItem("test", newURL, "", false)
+
+	assets, err := HTMLAssets(item)
+	if err != nil {
+		t.Errorf("HTMLAssets error = %v", err)
+	}
+	if len(assets) != 2 {
+		t.Errorf("We couldn't extract all audio/video assets.")
+	}
+}
+
+// Test [data-item], [style], [data-preview] attribute extraction
+func TestHTMLAssetsAttributes(t *testing.T) {
+	html := `
+	<html>
+		<head></head>
+		<body>
+		 <div style="background: url('http://something.com/data.jpg')"></div>
+	   <div data-preview="http://archive.org">...</div>
+			<p>test</p>
+			<div data-item='{"id": 123, "name": "Sample Item", "image": "https://example.com/image.jpg"}'>
+    		Click here for details
+			</div>
+		</body>
+	</html>
+	`
+
+	resp := &http.Response{
+		Body: io.NopCloser(bytes.NewBufferString(html)),
+	}
+	newURL := &models.URL{Raw: "http://ex.com"}
+	newURL.SetResponse(resp)
+	err := archiver.ProcessBody(newURL, false, false, 0, os.TempDir())
+	if err != nil {
+		t.Errorf("ProcessBody() error = %v", err)
+	}
+	item := models.NewItem("test", newURL, "", false)
+
+	assets, err := HTMLAssets(item)
+	if err != nil {
+		t.Errorf("HTMLAssets error = %v", err)
+	}
+	if len(assets) != 3 {
+		t.Errorf("We couldn't extract all [data-item], [style], [data-preview] attribute assets. %d", len(assets))
+	}
+}


### PR DESCRIPTION
Group video[src] and audio[src] selections in the same `goquery.Find` query because their handling is identical.

Group scanning all doc element for attributes `[data-item], [style], [data-preview]` in the same `goquery.Find` query.
The previous query `goquery.Find('*')` was returning all elements and then we checked for specific attributes.
The new query returns only the elements which have one of the specified attributes, so it should be much faster.

Add unit tests to validate the suggested improvements.