### PR TITLE
Revamp WARC writing queue watcher

### DIFF
--- a/internal/pkg/archiver/archiver.go
+++ b/internal/pkg/archiver/archiver.go
@@ -66,7 +66,6 @@ func Start(inputChan, outputChan chan *models.Item) error {
 
 		// Setup WARC writing HTTP clients
 		startWARCWriter()
-		go watchWARCWritingQueue(250 * time.Millisecond)
 
 		logger.Debug("WARC writer started")
 
@@ -112,8 +111,6 @@ func Stop() {
 			globalArchiver.ClientWithProxy.WaitGroup.Wait()
 			globalArchiver.ClientWithProxy.Close()
 		}
-
-		watchWARCWritingQueueCancel()
 
 		logger.Info("stopped")
 	}

--- a/internal/pkg/archiver/warc.go
+++ b/internal/pkg/archiver/warc.go
@@ -1,15 +1,12 @@
 package archiver
 
 import (
-	"context"
 	"os"
 	"path"
 	"time"
 
 	"github.com/CorentinB/warc"
 	"github.com/internetarchive/Zeno/internal/pkg/config"
-	"github.com/internetarchive/Zeno/internal/pkg/log"
-	"github.com/internetarchive/Zeno/internal/pkg/stats"
 )
 
 func startWARCWriter() {
@@ -112,27 +109,4 @@ func GetWARCWritingQueueSize() (total int) {
 	}
 
 	return total
-}
-
-var (
-	watchWARCWritingQueueContext, watchWARCWritingQueueCancel = context.WithCancel(context.Background())
-)
-
-func watchWARCWritingQueue(interval time.Duration) {
-	logger := log.NewFieldedLogger(&log.Fields{
-		"component": "archiver.warcWritingQueueWatcher",
-	})
-
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-watchWARCWritingQueueContext.Done():
-			logger.Debug("closed")
-			return
-		case <-ticker.C:
-			stats.WarcWritingQueueSizeSet(int64(GetWARCWritingQueueSize()))
-		}
-	}
 }

--- a/internal/pkg/controler/pipeline.go
+++ b/internal/pkg/controler/pipeline.go
@@ -98,7 +98,7 @@ func startPipeline() {
 	}
 
 	// Start the WARC writing queue watcher
-	watchers.StartWatchWARCWritingQueue(5*time.Second, 1*time.Second, 250*time.Millisecond)
+	watchers.StartWatchWARCWritingQueue(1*time.Second, 2*time.Second, 250*time.Millisecond)
 
 	postprocessorOutputChan := makeStageChannel(config.Get().WorkersCount)
 	err = postprocessor.Start(archiverOutputChan, postprocessorOutputChan)

--- a/internal/pkg/controler/pipeline.go
+++ b/internal/pkg/controler/pipeline.go
@@ -98,7 +98,7 @@ func startPipeline() {
 	}
 
 	// Start the WARC writing queue watcher
-	go watchers.WatchWARCWritingQueue(5 * time.Second)
+	watchers.StartWatchWARCWritingQueue(5*time.Second, 1*time.Second, 250*time.Millisecond)
 
 	postprocessorOutputChan := makeStageChannel(config.Get().WorkersCount)
 	err = postprocessor.Start(archiverOutputChan, postprocessorOutputChan)

--- a/internal/pkg/controler/watchers/warc.go
+++ b/internal/pkg/controler/watchers/warc.go
@@ -9,6 +9,7 @@ import (
 	"github.com/internetarchive/Zeno/internal/pkg/config"
 	"github.com/internetarchive/Zeno/internal/pkg/controler/pause"
 	"github.com/internetarchive/Zeno/internal/pkg/log"
+	"github.com/internetarchive/Zeno/internal/pkg/stats"
 )
 
 var (
@@ -16,48 +17,80 @@ var (
 	wwqWg             sync.WaitGroup
 )
 
-// WatchWARCWritingQueue watches the WARC writing queue size and pauses the pipeline if it exceeds the worker count
-func WatchWARCWritingQueue(interval time.Duration) {
+// StartWatchWARCWritingQueue watches the WARC writing queue size and pauses the pipeline if it exceeds the worker count
+func StartWatchWARCWritingQueue(pauseCheckInterval time.Duration, pauseTimeout time.Duration, statsUpdateInterval time.Duration) {
+	// Watch the WARC writing queue size and pause the pipeline if it exceeds the worker count
 	wwqWg.Add(1)
-	defer wwqWg.Done()
+	go func() {
+		defer wwqWg.Done()
 
-	logger := log.NewFieldedLogger(&log.Fields{
-		"component": "controler.warcWritingQueueWatcher",
-	})
+		logger := log.NewFieldedLogger(&log.Fields{
+			"component": "controler.warcWritingQueueWatcher.pause",
+		})
+		defer logger.Debug("closed")
 
-	paused := false
-	returnASAP := false
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
+		var lastPauseTime time.Time
+		paused := false
+		returnAfterResume := false
 
-	for {
-		select {
-		case <-wwqCtx.Done():
-			defer logger.Debug("closed")
-			if paused {
-				logger.Info("returning after resume")
-				returnASAP = true
-			}
-			return
-		case <-ticker.C:
-			queueSize := archiver.GetWARCWritingQueueSize()
+		pauseTicker := time.NewTicker(pauseCheckInterval)
+		defer pauseTicker.Stop()
 
-			logger.Debug("checking queue size", "queue_size", queueSize, "max_queue_size", config.Get().WorkersCount, "paused", paused)
-
-			if queueSize > config.Get().WorkersCount && !paused {
-				logger.Warn("WARC writing queue exceeded the worker count, pausing the pipeline")
-				pause.Pause("WARC writing queue exceeded the worker count")
-				paused = true
-			} else if queueSize < config.Get().WorkersCount && paused {
-				logger.Info("WARC writing queue size returned to acceptable, resuming the pipeline")
-				pause.Resume()
-				paused = false
-				if returnASAP {
+		for {
+			select {
+			case <-wwqCtx.Done():
+				if paused && !returnAfterResume {
+					logger.Info("returning after resume")
+					returnAfterResume = true
+				} else {
 					return
+				}
+			case <-pauseTicker.C:
+				queueSize := archiver.GetWARCWritingQueueSize()
+
+				logger.Debug("checking queue size for pause", "queue_size", queueSize, "max_queue_size", config.Get().WorkersCount, "paused", paused)
+
+				if !paused && queueSize > config.Get().WorkersCount {
+					logger.Warn("WARC writing queue exceeded the worker count, pausing the pipeline")
+					pause.Pause("WARC writing queue exceeded the worker count")
+					paused = true
+					lastPauseTime = time.Now()
+				} else if paused && time.Since(lastPauseTime) >= pauseTimeout && queueSize < config.Get().WorkersCount {
+					logger.Info("WARC writing queue size returned to acceptable, resuming the pipeline")
+					pause.Resume()
+					paused = false
+					if returnAfterResume {
+						return
+					}
 				}
 			}
 		}
-	}
+	}()
+
+	// Update the stats every statsUpdateInterval
+	wwqWg.Add(1)
+	go func() {
+		defer wwqWg.Done()
+
+		logger := log.NewFieldedLogger(&log.Fields{
+			"component": "controler.warcWritingQueueWatcher.stats",
+		})
+		defer logger.Debug("closed")
+
+		statsTicker := time.NewTicker(statsUpdateInterval)
+		defer statsTicker.Stop()
+
+		for {
+			select {
+			case <-wwqCtx.Done():
+				return
+			case <-statsTicker.C:
+				queueSize := archiver.GetWARCWritingQueueSize()
+
+				stats.WarcWritingQueueSizeSet(int64(queueSize))
+			}
+		}
+	}()
 }
 
 // StopWARCWritingQueueWatcher stops the WARC writing queue watcher by canceling the context and waiting for the goroutine to finish


### PR DESCRIPTION
- Removed the `archiver` local WARC Writing queue watcher in benefit of `controler/watchers` one
- Made the `controler/watchers` WARC WQ watcher also update stats
- Made the `controler/watchers` WARC WQ watcher respect a timeout for unpausing to avoid pausing and unpausing too fast under high contention
- Optimized `if` statements in `controler/watchers` WARC WQ watcher to avoid computing values when not needed (put bool check as first condition)