### PR TITLE
🐞 fix: toolchain not available error by specifying full Go version 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/internetarchive/Zeno
 
-go 1.24
+go 1.24.0
 
 require (
 	github.com/CorentinB/warc v0.8.71


### PR DESCRIPTION
https://github.com/golang/go/issues/65568#issuecomment-1954876836

Running into issue while installing the specific version of go. in the project. 
This simple change seems to fix this