### PR TITLE
Enhanced Non UTF8 HTML Support

### DIFF
--- a/internal/pkg/postprocessor/extractor/html.go
+++ b/internal/pkg/postprocessor/extractor/html.go
@@ -41,12 +41,23 @@ func HTMLOutlinks(item *models.Item) (outlinks []*models.URL, err error) {
 	// Extract the base tag if it exists
 	extractBaseTag(item, document)
 
+	// Define the valid link attributes to check
+	validLinkAttributes := []string{
+		"href",
+		"data-href",
+		"data-src",
+		"data-srcset",
+		"data-lazy-src",
+		"src",
+		"srcset",
+	}
+
 	// Match <a> tags with href, data-href, data-src, data-srcset, data-lazy-src, data-srcset, src, srcset
 	if !slices.Contains(config.Get().DisableHTMLTag, "a") {
 		document.Find("a").Each(func(index int, i *goquery.Selection) {
-			for _, node := range i.Nodes {
-				for _, attr := range node.Attr {
-					link := attr.Val
+			for _, attr := range validLinkAttributes {
+				link, exists := i.Attr(attr)
+				if exists && link != "" {
 					rawOutlinks = append(rawOutlinks, link)
 				}
 			}
@@ -57,16 +68,22 @@ func HTMLOutlinks(item *models.Item) (outlinks []*models.URL, err error) {
 		resolvedURL, err := resolveURL(rawOutlink, item)
 		if err != nil {
 			logger.Debug("unable to resolve URL", "error", err, "url", item.GetURL().String(), "item", item.GetShortID())
-		} else if resolvedURL != "" {
 			outlinks = append(outlinks, &models.URL{
-				Raw: resolvedURL,
+				Raw: rawOutlink,
 			})
-			continue
+		} else if resolvedURL != "" {
+			normalizedURL, err := item.GetURL().NormalizeURL(resolvedURL)
+			if err != nil {
+				logger.Debug("unable to normalize URL", "error", err, "url", resolvedURL, "item", item.GetShortID())
+				outlinks = append(outlinks, &models.URL{
+					Raw: resolvedURL,
+				})
+			} else {
+				outlinks = append(outlinks, &models.URL{
+					Raw: normalizedURL,
+				})
+			}
 		}
-
-		outlinks = append(outlinks, &models.URL{
-			Raw: rawOutlink,
-		})
 	}
 
 	return outlinks, nil
@@ -77,7 +94,27 @@ func HTMLAssets(item *models.Item) (assets []*models.URL, err error) {
 		"component": "postprocessor.extractor.HTMLAssets",
 	})
 
-	var rawAssets []string
+	rawAssetsMap := make(map[string]bool)
+	// Helper function to add to map instead of directly to slice
+	addRawAsset := func(url string) {
+		if url == "" {
+			return
+		}
+
+		// Don't extract CSS elements that aren't URLs
+		if strings.Contains(url, "%") ||
+			strings.HasPrefix(url, "0.") ||
+			strings.HasPrefix(url, "--font") ||
+			strings.HasPrefix(url, "--size") ||
+			strings.HasPrefix(url, "--color") ||
+			strings.HasPrefix(url, "--shreddit") ||
+			strings.HasPrefix(url, "100vh") ||
+			strings.HasPrefix(url, "#wp-") {
+			return
+		}
+
+		rawAssetsMap[url] = true
+	}
 
 	// Retrieve (potentially creates it) the document from the body
 	document, err := item.GetURL().GetDocument()
@@ -97,7 +134,9 @@ func HTMLAssets(item *models.Item) (assets []*models.URL, err error) {
 			if err != nil {
 				logger.Debug("unable to extract URLs from JSON in data-item attribute", "err", err, "url", item.GetURL().String(), "item", item.GetShortID())
 			} else {
-				rawAssets = append(rawAssets, URLsFromJSON...)
+				for _, url := range URLsFromJSON {
+					addRawAsset(url)
+				}
 			}
 		}
 
@@ -108,19 +147,7 @@ func HTMLAssets(item *models.Item) (assets []*models.URL, err error) {
 			for match := range matches {
 				if len(matches[match]) > 0 {
 					matchFound := matches[match][1]
-
-					// Don't extract CSS elements that aren't URLs
-					if strings.Contains(matchFound, "%") ||
-						strings.HasPrefix(matchFound, "0.") ||
-						strings.HasPrefix(matchFound, "--font") ||
-						strings.HasPrefix(matchFound, "--size") ||
-						strings.HasPrefix(matchFound, "--color") ||
-						strings.HasPrefix(matchFound, "--shreddit") ||
-						strings.HasPrefix(matchFound, "100vh") {
-						continue
-					}
-
-					rawAssets = append(rawAssets, matchFound)
+					addRawAsset(matchFound)
 				}
 			}
 		}
@@ -128,31 +155,20 @@ func HTMLAssets(item *models.Item) (assets []*models.URL, err error) {
 		dataPreview, exists := i.Attr("data-preview")
 		if exists {
 			if strings.HasPrefix(dataPreview, "http") {
-				rawAssets = append(rawAssets, dataPreview)
+				addRawAsset(dataPreview)
 			}
 		}
 	})
 
-	// Try to find assets in <a> tags.. this is a bit funky
+	// Try to find assets in <a> tags
 	if !slices.Contains(config.Get().DisableHTMLTag, "a") {
 		var validAssetPath = []string{
-			"static/",
-			"assets/",
-			"asset/",
-			"images/",
-			"image/",
-			"img/",
+			"static/", "assets/", "asset/", "images/", "image/", "img/",
 		}
 
 		var validAssetAttributes = []string{
-			"href",
-			"data-href",
-			"data-src",
-			"data-srcset",
-			"data-lazy-src",
-			"data-srcset",
-			"src",
-			"srcset",
+			"href", "data-href", "data-src", "data-srcset",
+			"data-lazy-src", "data-srcset", "src", "srcset",
 		}
 
 		document.Find("a").Each(func(index int, i *goquery.Selection) {
@@ -160,49 +176,36 @@ func HTMLAssets(item *models.Item) (assets []*models.URL, err error) {
 				link, exists := i.Attr(attr)
 				if exists {
 					if utils.StringContainsSliceElements(link, validAssetPath) {
-						rawAssets = append(rawAssets, link)
+						addRawAsset(link)
 					}
 				}
 			}
 		})
 	}
 
-	// Extract assets on the page (images, scripts, videos..)
+	// Handle <img> tags
 	if !slices.Contains(config.Get().DisableHTMLTag, "img") {
 		document.Find("img").Each(func(index int, i *goquery.Selection) {
-			link, exists := i.Attr("src")
-			if exists {
-				rawAssets = append(rawAssets, link)
-			}
-
-			link, exists = i.Attr("data-src")
-			if exists {
-				rawAssets = append(rawAssets, link)
-			}
-
-			link, exists = i.Attr("data-lazy-src")
-			if exists {
-				rawAssets = append(rawAssets, link)
-			}
-
-			link, exists = i.Attr("data-srcset")
-			if exists {
-				links := strings.Split(link, ",")
-				for _, link := range links {
-					rawAssets = append(rawAssets, strings.Split(strings.TrimSpace(link), " ")[0])
+			// Handle various image attributes
+			for _, attr := range []string{"src", "data-src", "data-lazy-src"} {
+				if link, exists := i.Attr(attr); exists {
+					addRawAsset(link)
 				}
 			}
 
-			link, exists = i.Attr("srcset")
-			if exists {
-				links := strings.Split(link, ",")
-				for _, link := range links {
-					rawAssets = append(rawAssets, strings.Split(strings.TrimSpace(link), " ")[0])
+			// Handle srcset and data-srcset attributes
+			for _, srcsetAttr := range []string{"srcset", "data-srcset"} {
+				if link, exists := i.Attr(srcsetAttr); exists {
+					links := strings.Split(link, ",")
+					for _, link := range links {
+						addRawAsset(strings.Split(strings.TrimSpace(link), " ")[0])
+					}
 				}
 			}
 		})
 	}
 
+	// Handle video and audio tags
 	var targetElements = []string{}
 	if !slices.Contains(config.Get().DisableHTMLTag, "video") {
 		targetElements = append(targetElements, "video[src]")
@@ -213,11 +216,12 @@ func HTMLAssets(item *models.Item) (assets []*models.URL, err error) {
 	if len(targetElements) > 0 {
 		document.Find(strings.Join(targetElements, ", ")).Each(func(index int, i *goquery.Selection) {
 			if link, exists := i.Attr("src"); exists {
-				rawAssets = append(rawAssets, link)
+				addRawAsset(link)
 			}
 		})
 	}
 
+	// Handle style tags
 	if !slices.Contains(config.Get().DisableHTMLTag, "style") {
 		document.Find("style").Each(func(index int, i *goquery.Selection) {
 			matches := urlRegex.FindAllStringSubmatch(i.Text(), -1)
@@ -225,72 +229,59 @@ func HTMLAssets(item *models.Item) (assets []*models.URL, err error) {
 				matchReplacement := matches[match][1]
 				matchReplacement = strings.Replace(matchReplacement, "'", "", -1)
 				matchReplacement = strings.Replace(matchReplacement, "\"", "", -1)
-
-				// If the URL already has http (or https), we don't need add anything to it.
 				if !strings.Contains(matchReplacement, "http") {
 					matchReplacement = strings.Replace(matchReplacement, "//", "http://", -1)
 				}
-
-				if strings.HasPrefix(matchReplacement, "#wp-") {
-					continue
-				}
-
-				rawAssets = append(rawAssets, matchReplacement)
+				addRawAsset(matchReplacement)
 			}
 		})
 	}
 
+	// Handle script tags
 	if !slices.Contains(config.Get().DisableHTMLTag, "script") {
 		document.Find("script").Each(func(index int, i *goquery.Selection) {
-			link, exists := i.Attr("src")
-			if exists {
-				rawAssets = append(rawAssets, link)
+			if link, exists := i.Attr("src"); exists {
+				addRawAsset(link)
 			}
 
 			scriptType, exists := i.Attr("type")
-			if exists {
-				if scriptType == "application/json" {
-					URLsFromJSON, _, err := GetURLsFromJSON(json.NewDecoder(strings.NewReader(i.Text())))
-					if err != nil {
-						// TODO: maybe add back when https://github.com/internetarchive/Zeno/issues/147 is fixed
-						// c.Log.Debug("unable to extract URLs from JSON in script tag", "error", err, "url", URL)
-					} else {
-						rawAssets = append(rawAssets, URLsFromJSON...)
+			if exists && scriptType == "application/json" {
+				URLsFromJSON, _, err := GetURLsFromJSON(json.NewDecoder(strings.NewReader(i.Text())))
+				if err == nil {
+					for _, url := range URLsFromJSON {
+						addRawAsset(url)
 					}
 				}
 			}
 
 			// Apply regex on the script's HTML to extract potential assets
 			outerHTML, err := goquery.OuterHtml(i)
-			if err != nil {
-				logger.Debug("unable to extract outer HTML from script tag", "err", err, "url", item.GetURL().String(), "item", item.GetShortID())
-			} else {
+			if err == nil {
 				scriptLinks := utils.DedupeStrings(LinkRegexRelaxed.FindAllString(outerHTML, -1))
 				for _, scriptLink := range scriptLinks {
 					if strings.HasPrefix(scriptLink, "http") {
 						// Escape URLs when unicode runes are present in the extracted URLs
-						scriptLink, err := strconv.Unquote(`"` + scriptLink + `"`)
-						if err != nil {
-							logger.Debug("unable to escape URL from JSON in script tag", "error", err, "url", item.GetURL().String(), "item", item.GetShortID())
-							continue
+						escapedLink, err := strconv.Unquote(`"` + scriptLink + `"`)
+						if err == nil {
+							addRawAsset(escapedLink)
 						}
-						rawAssets = append(rawAssets, scriptLink)
 					}
 				}
 			}
 
-			// Some <script> embed variable initialisation, we can strip the variable part and just scrape JSON
+			// Handle variable initialization in scripts
 			if !strings.HasPrefix(i.Text(), "{") {
 				assetsFromScriptContent, err := extractFromScriptContent(i.Text())
-				if err != nil {
-					logger.Debug("unable to extract URLs from JSON in script tag", "error", err, "url", item.GetURL().String(), "item", item.GetShortID())
-				} else {
-					rawAssets = append(rawAssets, assetsFromScriptContent...)
+				if err == nil {
+					for _, url := range assetsFromScriptContent {
+						addRawAsset(url)
+					}
 				}
 			}
 		})
 	}
 
+	// Handle link tags
 	if !slices.Contains(config.Get().DisableHTMLTag, "link") {
 		document.Find("link").Each(func(index int, i *goquery.Selection) {
 			if !config.Get().CaptureAlternatePages {
@@ -300,58 +291,57 @@ func HTMLAssets(item *models.Item) (assets []*models.URL, err error) {
 				}
 			}
 
-			link, exists := i.Attr("href")
-			if exists {
-				rawAssets = append(rawAssets, link)
+			if link, exists := i.Attr("href"); exists {
+				addRawAsset(link)
 			}
 		})
 	}
 
+	// Handle meta tags
 	if !slices.Contains(config.Get().DisableHTMLTag, "meta") {
 		document.Find("meta").Each(func(index int, i *goquery.Selection) {
-			link, exists := i.Attr("href")
-			if exists {
-				rawAssets = append(rawAssets, link)
+			if link, exists := i.Attr("href"); exists {
+				addRawAsset(link)
 			}
-			link, exists = i.Attr("content")
-			if exists {
-				if strings.Contains(link, "http") {
-					rawAssets = append(rawAssets, link)
-				}
+
+			if link, exists := i.Attr("content"); exists && strings.Contains(link, "http") {
+				addRawAsset(link)
 			}
 		})
 	}
 
+	// Handle source tags
 	if !slices.Contains(config.Get().DisableHTMLTag, "source") {
 		document.Find("source").Each(func(index int, i *goquery.Selection) {
-			link, exists := i.Attr("src")
-			if exists {
-				rawAssets = append(rawAssets, link)
+			if link, exists := i.Attr("src"); exists {
+				addRawAsset(link)
 			}
 
-			link, exists = i.Attr("srcset")
-			if exists {
-				links := strings.Split(link, ",")
-				for _, link := range links {
-					rawAssets = append(rawAssets, strings.Split(strings.TrimSpace(link), " ")[0])
-				}
-			}
-
-			link, exists = i.Attr("data-srcset")
-			if exists {
-				links := strings.Split(link, ",")
-				for _, link := range links {
-					rawAssets = append(rawAssets, strings.Split(strings.TrimSpace(link), " ")[0])
+			// Handle srcset and data-srcset attributes
+			for _, srcsetAttr := range []string{"srcset", "data-srcset"} {
+				if link, exists := i.Attr(srcsetAttr); exists {
+					links := strings.Split(link, ",")
+					for _, link := range links {
+						addRawAsset(strings.Split(strings.TrimSpace(link), " ")[0])
+					}
 				}
 			}
 		})
 	}
 
-	for _, rawAsset := range rawAssets {
+	var uniqueRawAssets []string
+	for asset := range rawAssetsMap {
+		uniqueRawAssets = append(uniqueRawAssets, asset)
+	}
+	// Create model URLs from unique raw assets
+	for _, rawAsset := range uniqueRawAssets {
+		normalizedURL, err := item.GetURL().NormalizeURL(rawAsset)
+		if err != nil {
+			normalizedURL = rawAsset
+		}
 		assets = append(assets, &models.URL{
-			Raw: rawAsset,
+			Raw: normalizedURL,
 		})
-
 	}
 
 	return assets, nil

--- a/internal/pkg/postprocessor/extractor/html_test.go
+++ b/internal/pkg/postprocessor/extractor/html_test.go
@@ -2,6 +2,7 @@ package extractor
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -15,16 +16,16 @@ import (
 func TestHTMLOutlinks(t *testing.T) {
 	config.InitConfig()
 	body := `
-	<html>
-		<head></head>
-		<body>
-			<a href="http://example.com">ex</a>
-			<a href="http://archive.org">ar</a>
-			<p>test</p>
-			<a href="https://web.archive.org">wa</a>
-		</body>
-	</html>
-	`
+<html>
+ <head></head>
+ <body>
+  <a href="http://example.com">ex</a>
+  <a href="http://archive.org">ar</a>
+  <p>test</p>
+  <a href="https://web.archive.org">wa</a>
+ </body>
+</html>
+`
 
 	resp := &http.Response{
 		Body: io.NopCloser(bytes.NewBufferString(body)),
@@ -41,8 +42,26 @@ func TestHTMLOutlinks(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error extracting HTML outlinks %s", err)
 	}
-	if len(outlinks) != 3 {
-		t.Errorf("We couldn't extract all HTML outlinks.")
+
+	expectedURLs := map[string]bool{
+		"http://example.com":      false,
+		"http://archive.org":      false,
+		"https://web.archive.org": false,
+	}
+
+	for _, link := range outlinks {
+		urlString := link.Raw
+		if _, exists := expectedURLs[urlString]; exists {
+			expectedURLs[urlString] = true
+		} else {
+			t.Errorf("Unexpected outlink found: %s", urlString)
+		}
+	}
+
+	for url, found := range expectedURLs {
+		if !found {
+			t.Errorf("Expected outlink not found: %s", url)
+		}
 	}
 }
 
@@ -50,15 +69,15 @@ func TestHTMLOutlinks(t *testing.T) {
 func TestHTMLAssetsAudioVideo(t *testing.T) {
 	config.InitConfig()
 	audioVideoBody := `
-	<html>
-		<head></head>
-		<body>
-			<video src="http://f1.com"></video>
-			<p>test</p>
-			<audio src="http://f2.com"></audio>
-		</body>
-	</html>
-	`
+<html>
+ <head></head>
+ <body>
+  <video src="http://f1.com"></video>
+  <p>test</p>
+  <audio src="http://f2.com"></audio>
+ </body>
+</html>
+`
 
 	resp := &http.Response{
 		Body: io.NopCloser(bytes.NewBufferString(audioVideoBody)),
@@ -75,8 +94,28 @@ func TestHTMLAssetsAudioVideo(t *testing.T) {
 	if err != nil {
 		t.Errorf("HTMLAssets error = %v", err)
 	}
-	if len(assets) != 2 {
-		t.Errorf("We couldn't extract all audio/video assets.")
+
+	expectedAssets := map[string]bool{
+		"http://f1.com": false,
+		"http://f2.com": false,
+	}
+
+	if len(assets) != len(expectedAssets) {
+		t.Errorf("Expected %d assets but got %d", len(expectedAssets), len(assets))
+	}
+
+	for _, asset := range assets {
+		if _, exists := expectedAssets[asset.Raw]; exists {
+			expectedAssets[asset.Raw] = true
+		} else {
+			t.Errorf("Unexpected asset found: %s", asset.Raw)
+		}
+	}
+
+	for url, found := range expectedAssets {
+		if !found {
+			t.Errorf("Expected asset not found: %s", url)
+		}
 	}
 }
 
@@ -84,18 +123,18 @@ func TestHTMLAssetsAudioVideo(t *testing.T) {
 func TestHTMLAssetsAttributes(t *testing.T) {
 	config.InitConfig()
 	html := `
-	<html>
-		<head></head>
-		<body>
-		 <div style="background: url('http://something.com/data.jpg')"></div>
-	   <div data-preview="http://archive.org">...</div>
-			<p>test</p>
-			<div data-item='{"id": 123, "name": "Sample Item", "image": "https://example.com/image.jpg"}'>
-    		Click here for details
-			</div>
-		</body>
-	</html>
-	`
+<html>
+ <head></head>
+ <body>
+  <div style="background: url('http://something.com/data.jpg')"></div>
+   <div data-preview="http://archive.org">...</div>
+  <p>test</p>
+  <div data-item='{"id": 123, "name": "Sample Item", "image": "https://example.com/image.jpg"}'>
+     Click here for details
+  </div>
+ </body>
+</html>
+`
 
 	resp := &http.Response{
 		Body: io.NopCloser(bytes.NewBufferString(html)),
@@ -112,7 +151,585 @@ func TestHTMLAssetsAttributes(t *testing.T) {
 	if err != nil {
 		t.Errorf("HTMLAssets error = %v", err)
 	}
-	if len(assets) != 3 {
-		t.Errorf("We couldn't extract all [data-item], [style], [data-preview] attribute assets. %d", len(assets))
+
+	expectedAssets := map[string]bool{
+		"http://something.com/data.jpg": false,
+		"http://archive.org":            false,
+		"https://example.com/image.jpg": false,
+	}
+
+	if len(assets) != len(expectedAssets) {
+		t.Errorf("Expected %d assets but got %d", len(expectedAssets), len(assets))
+	}
+
+	for _, asset := range assets {
+		if _, exists := expectedAssets[asset.Raw]; exists {
+			expectedAssets[asset.Raw] = true
+		} else {
+			t.Errorf("Unexpected asset found: %s", asset.Raw)
+		}
+	}
+
+	for url, found := range expectedAssets {
+		if !found {
+			t.Errorf("Expected asset not found: %s", url)
+		}
+	}
+}
+
+// TestHTMLOutlinksWithNonUTF8Encodings tests the HTMLOutlinks function with various encodings
+func TestHTMLOutlinksWithNonUTF8Encodings(t *testing.T) {
+	config.InitConfig()
+
+	iso8859_1_cafe := []byte("caf\xE9.com")   // café.com in ISO-8859-1
+	windows1252_euro := []byte("\x80uro.com") // €uro.com in Windows-1252
+
+	testCases := []struct {
+		name          string
+		contentType   string
+		body          []byte
+		expectedLinks map[string]bool
+		expectError   bool // Add expectation for error
+	}{
+		{
+			name:        "UTF-8 Encoding",
+			contentType: "text/html; charset=utf-8",
+			body:        []byte(`<html><body><a href="http://example.com">Example</a><a href="http://café.com">Café</a></body></html>`),
+			expectedLinks: map[string]bool{
+				"http://example.com": false,
+				"http://café.com":    false,
+			},
+			expectError: false,
+		},
+		{
+			name:        "ISO-8859-1 Encoding",
+			contentType: "text/html; charset=ISO-8859-1",
+			body:        []byte(fmt.Sprintf(`<html><body><a href="http://example.com">Example</a><a href="http://%s">Café</a></body></html>`, iso8859_1_cafe)),
+			expectedLinks: map[string]bool{
+				"http://example.com": false,
+				"http://café.com":    false,
+			},
+			expectError: false,
+		},
+		{
+			name:        "Windows-1252 Encoding",
+			contentType: "text/html; charset=windows-1252",
+			body:        []byte(fmt.Sprintf(`<html><body><a href="http://example.com">Example</a><a href="http://%s">Euro</a></body></html>`, windows1252_euro)),
+			expectedLinks: map[string]bool{
+				"http://example.com": false,
+				"http://€uro.com":    false,
+			},
+			expectError: false,
+		},
+		{
+			name:        "Missing Charset in Content-Type",
+			contentType: "text/html",
+			// ISO-8859-1 encoded HTML with meta charset tag
+			body: []byte(fmt.Sprintf(`<html><head><meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"></head><body><a href="http://example.com">Example</a><a href="http://%s">Café</a></body></html>`, iso8859_1_cafe)),
+			expectedLinks: map[string]bool{
+				"http://example.com": false,
+				"http://café.com":    false,
+			},
+			expectError: false,
+		},
+		{
+			name:        "Conflicting Charset",
+			contentType: "text/html; charset=utf-8",
+			// ISO-8859-1 encoded HTML with meta charset tag that conflicts with Content-Type
+			body: []byte(fmt.Sprintf(`<html><head><meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"></head><body><a href="http://example.com">Example</a><a href="http://%s">Café</a></body></html>`, iso8859_1_cafe)),
+			expectedLinks: map[string]bool{
+				"http://example.com": false,
+				"http://café.com":    false,
+			},
+			expectError: false,
+		},
+		{
+			// New test case for HTML5 meta charset tag
+			name:        "HTML5 Meta Charset",
+			contentType: "text/html; charset=utf-8",
+			body:        []byte(fmt.Sprintf(`<html><head><meta charset="ISO-8859-1"></head><body><a href="http://example.com">Example</a><a href="http://%s">Café</a></body></html>`, iso8859_1_cafe)),
+			expectedLinks: map[string]bool{
+				"http://example.com": false,
+				"http://café.com":    false,
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			bodyBuffer := bytes.NewBuffer(tc.body)
+			resp := &http.Response{
+				Body: io.NopCloser(bodyBuffer),
+				Header: http.Header{
+					"Content-Type": []string{tc.contentType},
+				},
+			}
+
+			newURL := &models.URL{Raw: "http://ex.com"}
+			newURL.SetResponse(resp)
+			err := archiver.ProcessBody(newURL, false, false, 0, os.TempDir())
+			if err != nil {
+				t.Errorf("ProcessBody() error = %v", err)
+			}
+
+			// Reset the body by creating a new reader
+			resp.Body = io.NopCloser(bytes.NewReader(bodyBuffer.Bytes()))
+			item := models.NewItem("test", newURL, "")
+			outlinks, err := HTMLOutlinks(item)
+
+			if tc.expectError {
+				if err == nil {
+					t.Errorf("Expected an error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("HTMLOutlinks error: %v", err)
+			}
+
+			// Check if all expected links are found
+			if len(outlinks) != len(tc.expectedLinks) {
+				t.Errorf("Expected %d outlinks, got %d", len(tc.expectedLinks), len(outlinks))
+				for i, link := range outlinks {
+					t.Logf("  Outlink %d: %s", i+1, link.Raw)
+				}
+			}
+
+			// Mark expected links as found
+			for _, link := range outlinks {
+				if _, exists := tc.expectedLinks[link.Raw]; exists {
+					tc.expectedLinks[link.Raw] = true
+				} else {
+					t.Errorf("Unexpected outlink found: %s", link.Raw)
+				}
+			}
+
+			// Check if any expected links are missing
+			for url, found := range tc.expectedLinks {
+				if !found {
+					t.Errorf("Expected outlink not found: %s", url)
+				}
+			}
+		})
+	}
+}
+
+// TestHTMLAssetsWithNonUTF8Encodings tests the HTMLAssets function with various encodings
+func TestHTMLAssetsWithNonUTF8Encodings(t *testing.T) {
+	config.InitConfig()
+
+	iso8859_1_cafe := []byte("caf\xE9.com") // café.com in ISO-8859-1
+
+	testCases := []struct {
+		name          string
+		contentType   string
+		body          []byte
+		expectedLinks []string
+		expectError   bool
+	}{
+		{
+			name:        "Complex HTML with Multiple Assets",
+			contentType: "text/html; charset=ISO-8859-1",
+			body: []byte(fmt.Sprintf(`
+            <html>
+            <head>
+            <link href="http://example.com/style.css" rel="stylesheet">
+            <script src="http://example.com/script.js"></script>
+            </head>
+            <body>
+                <img src="http://example.com/image.jpg">
+                <div style="background-image: url('http://%s/bg.jpg')"></div>
+                <video src="http://example.com/video.mp4"></video>
+                <audio src="http://example.com/audio.mp3"></audio>
+                <source srcset="http://example.com/img.jpg 1x, http://example.com/img@2x.jpg 2x">
+                <div data-preview="http://example.com/preview.jpg"></div>
+            </body>
+            </html>`, iso8859_1_cafe)),
+			expectedLinks: []string{
+				"http://example.com/style.css",
+				"http://example.com/script.js",
+				"http://example.com/image.jpg",
+				"http://café.com/bg.jpg",
+				"http://example.com/video.mp4",
+				"http://example.com/audio.mp3",
+				"http://example.com/img.jpg",
+				"http://example.com/img@2x.jpg",
+				"http://example.com/preview.jpg",
+			},
+			expectError: false,
+		},
+		{
+			// Add test case for complex srcset attribute
+			name:        "Complex srcset Attribute",
+			contentType: "text/html; charset=utf-8",
+			body: []byte(`
+            <html>
+            <head></head>
+            <body>
+                <img srcset="/image.jpg 480w, 
+                            /large.jpg 800w 2x, 
+                            /xlarge.jpg 1200w">
+                <picture>
+                    <source srcset="http://example.com/img-1x.jpg 1x, 
+                                   http://example.com/img-2x.jpg 2x, 
+                                   http://example.com/img-3x.jpg 3x">
+                    <img src="http://example.com/fallback.jpg">
+                </picture>
+            </body>
+            </html>`),
+			expectedLinks: []string{
+				"/image.jpg",
+				"/large.jpg",
+				"/xlarge.jpg",
+				"http://example.com/img-1x.jpg",
+				"http://example.com/img-2x.jpg",
+				"http://example.com/img-3x.jpg",
+				"http://example.com/fallback.jpg",
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			bodyBuffer := bytes.NewBuffer(tc.body)
+			resp := &http.Response{
+				Body: io.NopCloser(bodyBuffer),
+				Header: http.Header{
+					"Content-Type": []string{tc.contentType},
+				},
+			}
+			newURL := &models.URL{Raw: "http://ex.com"}
+			newURL.SetResponse(resp)
+			err := archiver.ProcessBody(newURL, false, false, 0, os.TempDir())
+			if err != nil {
+				t.Errorf("ProcessBody() error = %v", err)
+			}
+
+			// Reset the body by creating a new reader
+			resp.Body = io.NopCloser(bytes.NewReader(bodyBuffer.Bytes()))
+			item := models.NewItem("test", newURL, "")
+			assets, err := HTMLAssets(item)
+
+			if tc.expectError {
+				if err == nil {
+					t.Errorf("Expected an error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("HTMLAssets error: %v", err)
+			}
+
+			// Check that we have the expected number of assets
+			if len(assets) != len(tc.expectedLinks) {
+				t.Errorf("Expected %d assets, got %d", len(tc.expectedLinks), len(assets))
+				for i, asset := range assets {
+					t.Logf("  Asset %d: %s", i+1, asset.Raw)
+				}
+			}
+
+			// Create a map of expected links for easier lookup
+			expectedLinksMap := make(map[string]bool)
+			for _, link := range tc.expectedLinks {
+				expectedLinksMap[link] = false
+			}
+
+			// Check that each asset's Raw URL is in our expected list
+			for _, asset := range assets {
+				assetURL := asset.Raw
+				if _, exists := expectedLinksMap[assetURL]; !exists {
+					t.Errorf("Unexpected asset URL: %s", assetURL)
+				} else {
+					expectedLinksMap[assetURL] = true
+				}
+			}
+
+			// Check that all expected links were found
+			for link, found := range expectedLinksMap {
+				if !found {
+					t.Errorf("Expected asset not found: %s", link)
+				}
+			}
+		})
+	}
+}
+
+// TestHTMLWithMalformedContent tests the HTML extraction with malformed content
+func TestHTMLWithMalformedContent(t *testing.T) {
+	config.InitConfig()
+
+	testCases := []struct {
+		name        string
+		contentType string
+		body        []byte
+		expectError bool
+		comment     string // Add explanations for expected behavior
+	}{
+		{
+			name:        "Malformed HTML - Missing Closing Tags",
+			contentType: "text/html; charset=utf-8",
+			body:        []byte(`<html><body><a href="http://example.com">Example</a><div>`), // Missing closing div and body tags
+			expectError: false,
+			comment:     "goquery should handle missing closing tags gracefully",
+		},
+		{
+			name:        "Malformed HTML - Mismatched Tags",
+			contentType: "text/html; charset=utf-8",
+			body:        []byte(`<html><body><div><p>Text</div></body></html>`),
+			expectError: false,
+			comment:     "goquery should handle mismatched tags gracefully",
+		},
+		{
+			name:        "Malformed HTML - Unexpected Characters",
+			contentType: "text/html; charset=utf-8",
+			body:        []byte(`<html <body><a href="http://example.com">Example</a></body></html>`),
+			expectError: false,
+			comment:     "HTML parsers typically handle unexpected characters within tag boundaries",
+		},
+		{
+			name:        "Invalid Charset",
+			contentType: "text/html; charset=invalid-charset",
+			body:        []byte(`<html><body><a href="http://example.com">Example</a></body></html>`),
+			expectError: false,
+			comment:     "Should fall back to UTF-8 when charset is invalid",
+		},
+		{
+			name:        "Malformed HTML - Text with non-ASCII",
+			contentType: "text/html",
+			body:        []byte("<html><body>This is some text with non-ASCII characters like éèà.</body></html>"),
+			expectError: false,
+			comment:     "Non-ASCII characters should be handled correctly in UTF-8 encoded content",
+		},
+		{
+			name:        "Truncated Attribute Value",
+			contentType: "text/html; charset=utf-8",
+			body:        []byte(`<html><body><a href="http://example.com`), // Truncated in the middle of attribute value
+			expectError: false,
+			comment:     "HTML parser should handle truncated attribute values gracefully",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Logf("Testing case: %s - %s", tc.name, tc.comment)
+
+			bodyBuffer := bytes.NewBuffer(tc.body)
+			resp := &http.Response{
+				Body: io.NopCloser(bodyBuffer),
+				Header: http.Header{
+					"Content-Type": []string{tc.contentType},
+				},
+			}
+
+			newURL := &models.URL{Raw: "http://ex.com"}
+			newURL.SetResponse(resp)
+			err := archiver.ProcessBody(newURL, false, false, 0, os.TempDir())
+			if err != nil {
+				// We expect ProcessBody to work even with malformed content
+				t.Logf("ProcessBody() error = %v", err)
+			}
+
+			// Reset the body by creating a new reader
+			resp.Body = io.NopCloser(bytes.NewReader(bodyBuffer.Bytes()))
+
+			item := models.NewItem("test", newURL, "")
+
+			outlinks, err := HTMLOutlinks(item)
+			if tc.expectError {
+				if err == nil {
+					t.Errorf("Expected error for malformed content but got none")
+				} else {
+					t.Logf("HTMLOutlinks returned error: %v", err)
+				}
+			} else if err != nil { // Log unexpected errors
+				t.Errorf("HTMLOutlinks returned unexpected error: %v", err)
+			} else {
+				// Optionally, verify that outlinks were processed correctly
+				t.Logf("Found %d outlinks", len(outlinks))
+			}
+
+			// Reset the body again for HTMLAssets
+			resp.Body = io.NopCloser(bytes.NewReader(bodyBuffer.Bytes()))
+
+			assets, err := HTMLAssets(item)
+			if tc.expectError {
+				if err == nil {
+					t.Errorf("Expected error for malformed content but got none")
+				} else {
+					t.Logf("HTMLAssets returned error: %v", err)
+				}
+			} else if err != nil { // Log unexpected errors.
+				t.Errorf("HTMLAssets returned unexpected error: %v", err)
+			} else {
+				// Optionally, verify that assets were processed correctly
+				t.Logf("Found %d assets", len(assets))
+			}
+		})
+	}
+}
+
+// TestHTMLOutlinksWithEncoding tests handling of different character encodings
+func TestHTMLOutlinksWithEncoding(t *testing.T) {
+	config.InitConfig()
+
+	shiftJIS_Japanese := []byte{0x93, 0xfa, 0x96, 0x7b, 0x8c, 0xea} // Japanese text in Shift-JIS
+	testCases := []struct {
+		name          string
+		contentType   string
+		body          []byte
+		expectedLinks int
+		comment       string
+	}{
+		{
+			name:        "ISO-8859-1 Encoding",
+			contentType: "text/html; charset=ISO-8859-1",
+			// This is an ISO-8859-1 encoded HTML with non-ASCII characters
+			body:          []byte("<html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=ISO-8859-1\"></head><body><a href=\"http://example.com\">Example</a><a href=\"http://caf\xe9.com\">Caf\xe9</a></body></html>"),
+			expectedLinks: 2,
+			comment:       "ISO-8859-1 encoding should handle é character correctly",
+		},
+		{
+			name:        "Windows-1252 Encoding",
+			contentType: "text/html; charset=windows-1252",
+			// This is a Windows-1252 encoded HTML with non-ASCII characters
+			body:          []byte("<html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=windows-1252\"></head><body><a href=\"http://example.com\">Example</a><a href=\"http://caf\xe9.com\">Caf\xe9</a><a href=\"http://\x80uro.com\">\x80uro</a></body></html>"),
+			expectedLinks: 3,
+			comment:       "Windows-1252 encoding should handle € (0x80) and é characters correctly",
+		},
+		{
+			name:        "Shift-JIS Encoding",
+			contentType: "text/html; charset=Shift_JIS",
+			// This is a simple Shift-JIS encoded HTML with Japanese characters
+			body:          []byte(fmt.Sprintf("<html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=Shift_JIS\"></head><body><a href=\"http://example.com\">%s</a><a href=\"http://japan.com\">Japan</a></body></html>", shiftJIS_Japanese)),
+			expectedLinks: 2,
+			comment:       "Shift-JIS encoding should handle Japanese characters correctly",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Logf("Testing case: %s - %s", tc.name, tc.comment)
+
+			bodyBuffer := bytes.NewBuffer(tc.body)
+			resp := &http.Response{
+				Body: io.NopCloser(bodyBuffer),
+				Header: http.Header{
+					"Content-Type": []string{tc.contentType},
+				},
+			}
+
+			newURL := &models.URL{Raw: "http://ex.com"}
+			newURL.SetResponse(resp)
+			err := archiver.ProcessBody(newURL, false, false, 0, os.TempDir())
+			if err != nil {
+				t.Errorf("ProcessBody() error = %v", err)
+			}
+
+			// Reset the body by creating a new reader
+			resp.Body = io.NopCloser(bytes.NewReader(bodyBuffer.Bytes()))
+
+			item := models.NewItem("test", newURL, "")
+
+			outlinks, err := HTMLOutlinks(item)
+			if err != nil {
+				t.Errorf("Error extracting HTML outlinks: %s", err)
+			}
+			if len(outlinks) != tc.expectedLinks {
+				t.Errorf("Expected %d outlinks, got %d", tc.expectedLinks, len(outlinks))
+			}
+
+			// Log the found outlinks for debugging
+			for i, link := range outlinks {
+				t.Logf("Outlink %d: %s", i+1, link.Raw)
+			}
+		})
+	}
+}
+
+// TestHTMLAssetsWithEncoding tests handling of assets in different character encodings
+func TestHTMLAssetsWithEncoding(t *testing.T) {
+	config.InitConfig()
+
+	shiftJIS_Japanese := []byte{0x93, 0xfa, 0x96, 0x7b} // Japanese characters in Shift-JIS
+	testCases := []struct {
+		name           string
+		contentType    string
+		body           []byte
+		expectedAssets int
+		comment        string
+	}{
+		{
+			name:        "ISO-8859-1 Encoding",
+			contentType: "text/html; charset=ISO-8859-1",
+			// ISO-8859-1 encoded HTML with image tags and style attributes
+			body:           []byte("<html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=ISO-8859-1\"></head><body><img src=\"http://example.com/image.jpg\"><div style=\"background-image: url('http://caf\xe9.com/bg.jpg')\"></div></body></html>"),
+			expectedAssets: 2,
+			comment:        "Should extract URLs with ISO-8859-1 encoded characters in style attributes",
+		},
+		{
+			name:        "Windows-1252 Encoding",
+			contentType: "text/html; charset=windows-1252",
+			// Windows-1252 encoded HTML with script and link tags
+			body:           []byte("<html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=windows-1252\"><link href=\"http://example.com/style.css\"></head><body><script src=\"http://example.com/script.js\"></script><div data-preview=\"http://\x80uro.com/preview.jpg\"></div></body></html>"),
+			expectedAssets: 3,
+			comment:        "Should extract URLs with Windows-1252 encoded characters in data attributes",
+		},
+		{
+			name:        "Shift-JIS Encoding",
+			contentType: "text/html; charset=Shift_JIS",
+			// Shift-JIS encoded HTML with video and source tags
+			body:           []byte(fmt.Sprintf("<html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=Shift_JIS\"></head><body><video src=\"http://example.com/video.mp4\"></video><source srcset=\"http://%s.com/img.jpg 1x, http://japan.com/img@2x.jpg 2x\"></body></html>", shiftJIS_Japanese)),
+			expectedAssets: 3, // video src + 2 srcset images
+			comment:        "Should extract URLs with Shift-JIS encoded characters in srcset attributes",
+		},
+		{
+			name:           "Multiple Meta Charset Tags",
+			contentType:    "text/html",
+			body:           []byte("<html><head><meta charset=\"utf-8\"><meta http-equiv=\"Content-Type\" content=\"text/html; charset=ISO-8859-1\"></head><body><img src=\"http://example.com/image.jpg\"><div style=\"background-image: url('http://caf\xe9.com/bg.jpg')\"></div></body></html>"),
+			expectedAssets: 2,
+			comment:        "Should prioritize the first charset declaration in meta tags",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			bodyBuffer := bytes.NewBuffer(tc.body)
+			resp := &http.Response{
+				Body: io.NopCloser(bodyBuffer),
+				Header: http.Header{
+					"Content-Type": []string{tc.contentType},
+				},
+			}
+
+			newURL := &models.URL{Raw: "http://ex.com"}
+			newURL.SetResponse(resp)
+			err := archiver.ProcessBody(newURL, false, false, 0, os.TempDir())
+			if err != nil {
+				t.Errorf("ProcessBody() error = %v", err)
+			}
+
+			// Reset the body by creating a new reader
+			resp.Body = io.NopCloser(bytes.NewReader(bodyBuffer.Bytes()))
+
+			item := models.NewItem("test", newURL, "")
+
+			assets, err := HTMLAssets(item)
+			if err != nil {
+				t.Errorf("HTMLAssets error = %v", err)
+			}
+
+			t.Logf("Test Case: %s - Found %d assets", tc.name, len(assets))
+			for i, asset := range assets {
+				t.Logf("  Asset %d: %s", i+1, asset.Raw) // Log each asset using Raw field
+			}
+
+			if len(assets) != tc.expectedAssets {
+				t.Errorf("Expected %d assets, got %d", tc.expectedAssets, len(assets))
+			}
+		})
 	}
 }

--- a/pkg/models/url.go
+++ b/pkg/models/url.go
@@ -1,6 +1,9 @@
 package models
 
 import (
+	"bufio"
+	"bytes"
+	"fmt"
 	"io"
 	"log/slog"
 	"net"
@@ -12,7 +15,10 @@ import (
 	"github.com/CorentinB/warc/pkg/spooledtempfile"
 	"github.com/PuerkitoBio/goquery"
 	"github.com/gabriel-vasile/mimetype"
+	"golang.org/x/net/html/charset"
 	"golang.org/x/net/idna"
+	"golang.org/x/text/encoding/htmlindex"
+	"golang.org/x/text/transform"
 )
 
 type URL struct {
@@ -28,6 +34,7 @@ type URL struct {
 
 	stringCache string
 	once        sync.Once
+	documentMu  sync.Mutex // Protect document parsing
 }
 
 func (u *URL) Parse() (err error) {
@@ -43,17 +50,254 @@ func (u *URL) SetBody(body spooledtempfile.ReadSeekCloser) {
 	u.body = body
 }
 
+func (u *URL) NormalizeURL(rawURL string) (string, error) {
+	if rawURL == "" {
+		return rawURL, nil
+	}
+
+	// Handle special cases like data: and javascript: URLs
+	if strings.HasPrefix(rawURL, "data:") || strings.HasPrefix(rawURL, "javascript:") {
+		return rawURL, nil
+	}
+
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		// Try to handle partially encoded URLs
+		decodedURL := rawURL
+
+		// Attempt to safely decode any percent-encoded sequences
+		// if possible in case of multiple encodings
+		// (this should be uncommon and is defensive)
+		for attempt := 0; attempt < 3; attempt++ {
+			prev := decodedURL
+			tmpDecoded, tmpErr := url.QueryUnescape(decodedURL)
+			if tmpErr != nil {
+				break
+			}
+			decodedURL = tmpDecoded
+			if decodedURL == prev {
+				break
+			}
+		}
+
+		// Try parsing again with our best attempt at decoding.
+		// If all else fails, return the original URL.
+		parsedURL, err = url.Parse(decodedURL)
+		if err != nil {
+			return rawURL, err
+		}
+	}
+
+	var normalizedURL strings.Builder
+	if parsedURL.Scheme != "" {
+		normalizedURL.WriteString(parsedURL.Scheme)
+		normalizedURL.WriteString("://")
+	}
+
+	if parsedURL.Host != "" {
+		// For IDN domains, make sure we're using the Unicode representation
+		host := parsedURL.Host
+		if strings.HasPrefix(host, "xn--") {
+			ascii, err := idna.ToUnicode(host)
+			if err == nil {
+				host = ascii
+			}
+		}
+		normalizedURL.WriteString(host)
+	}
+
+	// Add path (properly decoded to preserve Unicode)
+	if parsedURL.Path != "" {
+		if parsedURL.Host != "" && !strings.HasPrefix(parsedURL.Path, "/") {
+			normalizedURL.WriteString("/")
+		}
+		decodedPath, err := url.PathUnescape(parsedURL.Path)
+		if err == nil {
+			normalizedURL.WriteString(decodedPath)
+		} else {
+			normalizedURL.WriteString(parsedURL.Path)
+		}
+	}
+
+	// Add query and then fragment
+	if parsedURL.RawQuery != "" {
+		normalizedURL.WriteString("?")
+		normalizedURL.WriteString(parsedURL.RawQuery)
+	}
+
+	if parsedURL.Fragment != "" {
+		normalizedURL.WriteString("#")
+		normalizedURL.WriteString(parsedURL.Fragment)
+	}
+
+	return normalizedURL.String(), nil
+}
+
+func createDecodedReader(body io.Reader, contentType string) (io.Reader, error) {
+	if seeker, ok := body.(io.Seeker); ok {
+		_, err := seeker.Seek(0, io.SeekStart)
+		if err != nil {
+			return nil, fmt.Errorf("failed to rewind body: %w", err)
+		}
+	}
+
+	bufferedReader := bufio.NewReader(body)
+
+	// Detect charset from content by peeking
+	var detectedCharset string
+	if data, err := bufferedReader.Peek(1024); err == nil {
+		if _, name, ok := charset.DetermineEncoding(data, contentType); ok {
+			detectedCharset = name
+			slog.Debug("Detected charset", "charset", detectedCharset, "content-type", contentType)
+		}
+	}
+
+	// If no charset detected, try from content-type header
+	if detectedCharset == "" {
+		detectedCharset = getCharsetFromContentType(contentType)
+	}
+
+	// If still no charset, default to UTF-8
+	if detectedCharset == "" {
+		detectedCharset = "utf-8"
+	}
+
+	// If detected charset is UTF-8, return buffered reader with no changes
+	if strings.EqualFold(detectedCharset, "utf-8") {
+		return bufferedReader, nil
+	}
+
+	e, err := htmlindex.Get(detectedCharset)
+	if err != nil {
+		// If we can't get encoding, default to UTF-8 and return the original body which is already
+		// valid UTF-8.
+		slog.Warn("Unknown charset", "charset", detectedCharset, "error", err)
+		return body, nil
+	}
+	decoder := e.NewDecoder()
+	return transform.NewReader(bufferedReader, decoder), nil
+}
+
+func getCharsetFromContentType(contentType string) string {
+	if contentType == "" {
+		return ""
+	}
+	for _, param := range strings.Split(contentType, ";") {
+		param = strings.TrimSpace(param)
+		if strings.HasPrefix(param, "charset=") {
+			return strings.TrimPrefix(param, "charset=")
+		}
+	}
+	return ""
+}
+
 func (u *URL) GetDocument() (doc *goquery.Document, err error) {
+	u.documentMu.Lock()
+	defer u.documentMu.Unlock()
+
 	if u.document == nil {
-		u.document, err = goquery.NewDocumentFromReader(u.GetBody())
+		resp := u.GetResponse()
+		if resp == nil {
+			return nil, fmt.Errorf("response is nil for URL: %s", u.Raw)
+		}
+		err = u.RewindBody()
+		if err != nil {
+			return nil, err
+		}
+		contentType := resp.Header.Get("Content-Type")
+
+		// Use the determineCharset function. The ignored value can be used
+		// to debug the determined charset.
+		_, bodyReader, err := u.determineCharset(contentType)
+		if err != nil {
+			slog.Warn("failed to determine charset, proceeding with original body",
+				"error", err,
+				"url", u.Raw,
+				"content-type", contentType)
+			err = u.RewindBody()
+			if err != nil {
+				return nil, err
+			}
+			bodyReader = u.GetBody()
+		}
+
+		// Create the document from the properly decoded reader
+		u.document, err = goquery.NewDocumentFromReader(bodyReader)
 		if err != nil {
 			return nil, err
 		}
 
-		u.RewindBody()
+		// Rewind body again after parsing
+		err = u.RewindBody()
+		if err != nil {
+			return nil, fmt.Errorf("could not rewind body after parsing: %w", err)
+		}
 	}
 
 	return u.document, nil
+}
+
+func (u *URL) determineCharset(contentType string) (string, io.Reader, error) {
+	bodyBytes, err := io.ReadAll(u.GetBody())
+	if err != nil {
+		return "", nil, err
+	}
+
+	// Parse HTML to find meta tags first
+	doc, err := goquery.NewDocumentFromReader(bytes.NewReader(bodyBytes))
+	if err != nil {
+		// If parsing fails, fall back to header (or utf-8)
+		return u.determineCharsetFallback(contentType, bodyBytes)
+	}
+
+	var metaCharset string
+	doc.Find("meta").Each(func(i int, s *goquery.Selection) {
+		charsetVal, exists := s.Attr("charset")
+		if exists {
+			metaCharset = charsetVal
+			return
+		}
+
+		httpEquiv, httpExists := s.Attr("http-equiv")
+		content, contentExists := s.Attr("content")
+
+		if httpExists && strings.ToLower(httpEquiv) == "content-type" && contentExists {
+			if strings.Contains(content, "charset=") {
+				metaCharset = strings.TrimSpace(strings.TrimPrefix(content, "text/html; charset="))
+				return
+			}
+		}
+	})
+
+	if metaCharset != "" {
+		decodedReader, err := createDecodedReader(bytes.NewReader(bodyBytes), "text/html; charset="+metaCharset)
+		if err != nil {
+			return "", bytes.NewReader(bodyBytes), err
+		}
+		return metaCharset, decodedReader, nil
+	}
+
+	// If no meta charset found, fall back to header (or UTF-8)
+	return u.determineCharsetFallback(contentType, bodyBytes)
+
+}
+
+func (u *URL) determineCharsetFallback(contentType string, bodyBytes []byte) (string, io.Reader, error) {
+	headerCharset := getCharsetFromContentType(contentType)
+	if headerCharset != "" {
+		decodedReader, err := createDecodedReader(bytes.NewReader(bodyBytes), contentType)
+		if err != nil {
+			return "", bytes.NewReader(bodyBytes), err
+		}
+		return headerCharset, decodedReader, nil
+	}
+
+	// If no header charset found, use createDecodedReader with UTF-8 as the fallback.
+	decodedReader, err := createDecodedReader(bytes.NewReader(bodyBytes), "text/html; charset=utf-8")
+	if err != nil {
+		return "", bytes.NewReader(bodyBytes), err
+	}
+	return "utf-8", decodedReader, nil
 }
 
 func (u *URL) SetDocument(doc *goquery.Document) {
@@ -68,11 +312,15 @@ func (u *URL) SetMIMEType(mimetype *mimetype.MIME) {
 	u.mimetype = mimetype
 }
 
-func (u *URL) RewindBody() {
+func (u *URL) RewindBody() error {
+	if u.body == nil {
+		return fmt.Errorf("body is nil")
+	}
 	_, err := u.body.Seek(0, io.SeekStart)
 	if err != nil {
-		panic(err)
+		slog.Warn("failed to rewind body", "error", err)
 	}
+	return err
 }
 
 func (u *URL) SetRequest(r *http.Request) {
@@ -123,34 +371,38 @@ func (u *URL) String() string {
 func URLToString(URL *url.URL) string {
 	var err error
 
-	switch URL.Host {
+	// Clone the URL to avoid modifying the original
+	urlCopy := *URL
+
+	switch urlCopy.Host {
 	case "external-preview.redd.it", "styles.redditmedia.com", "preview.redd.it":
-		// Do nothing. We don't want to encode the URL for signature purposes. :(
+		// Do nothing. We don't want to encode the URL for signature purposes. :( [aka we do not convert to Punycode]
 		break
 	default:
-		URL.RawQuery = encodeQuery(URL.Query())
-	}
+		urlCopy.RawQuery = encodeQuery(urlCopy.Query())
 
-	URL.Host, err = idna.ToASCII(URL.Host)
-	if err != nil {
-		if strings.Contains(URL.Host, ":") {
-			hostWithoutPort, port, err := net.SplitHostPort(URL.Host)
-			if err != nil {
-				slog.Warn("cannot split host and port", "error", err)
-			} else {
-				hostWithoutPort, err = idna.ToASCII(hostWithoutPort)
-				if err == nil {
-					URL.Host = hostWithoutPort + ":" + port
+		// Convert to Punycode for normal hosts
+		urlCopy.Host, err = idna.ToASCII(urlCopy.Host)
+		if err != nil {
+			if strings.Contains(urlCopy.Host, ":") {
+				hostWithoutPort, port, err := net.SplitHostPort(urlCopy.Host)
+				if err != nil {
+					slog.Warn("cannot split host and port", "error", err)
 				} else {
-					slog.Warn("cannot encode punycode host without port to ASCII", "error", err)
+					hostWithoutPort, err = idna.ToASCII(hostWithoutPort)
+					if err == nil {
+						urlCopy.Host = hostWithoutPort + ":" + port
+					} else {
+						slog.Warn("cannot encode punycode host without port to ASCII", "error", err)
+					}
 				}
+			} else {
+				slog.Warn("cannot encode punycode host to ASCII", "error", err)
 			}
-		} else {
-			slog.Warn("cannot encode punycode host to ASCII", "error", err)
 		}
 	}
 
-	return URL.String()
+	return urlCopy.String()
 }
 
 // Encode encodes the values into “URL encoded” form


### PR DESCRIPTION
Follows the [recommended tips and trick](https://github.com/PuerkitoBio/goquery/wiki/Tips-and-tricks) to provide better support for different character encodings and character sets in HTML pages.

This adds additional test cases in `html_test.go`, makes changes to `html.go` to improve maintainability and robustness where applicable and adds methods to `models/url.go` to handle different character encodings. Test cases have also been changed in `html_test.go` to consider the assets that are extracted rather than purely the number of them that are extracted. 

I'm open to any feedback

Attempts to close #169.