### PR TITLE
chore: update Go version to 1.24 in workflows and Dockerfile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: linux
         goarch: amd64
-        goversion: 1.23.0
+        goversion: 1.24.0
         compress_assets: OFF
         md5sum: FALSE
         sha256sum: TRUE

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.23'
+        go-version: '1.24'
 
     - name: Build
       run: go build -v ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Start from the official Go Alpine image
-FROM golang:1.22.6-alpine3.20
+FROM golang:1.24-alpine3.20
 
 # Set the working directory inside the container
 WORKDIR /app


### PR DESCRIPTION
This pull request includes updates to the Go version used in various configuration files to ensure consistency across the project. The most important changes include updating the Go version in the GitHub Actions workflows and the Dockerfile.

Updates to Go version:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L20-R20): Updated the `goversion` from `1.23.0` to `1.24.0`.
* [`.github/workflows/go.yml`](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL19-R19): Updated the `go-version` from `1.23` to `1.24`.
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L2-R2): Updated the base image from `golang:1.22.6-alpine3.20` to `golang:1.24-alpine3.20`.