### PR TITLE
Enhance asset processing, video extraction (YouTube, Vimeo, Dailymotion), and host limitation in crawling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: linux
         goarch: amd64
-        goversion: 1.23.0
+        goversion: 1.24.0
         compress_assets: OFF
         md5sum: FALSE
         sha256sum: TRUE

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.23'
+        go-version: '1.24'
 
     - name: Build
       run: go build -v ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Start from the official Go Alpine image
-FROM golang:1.22.6-alpine3.20
+FROM golang:1.24-alpine3.20
 
 # Set the working directory inside the container
 WORKDIR /app

--- a/internal/pkg/crawl/utils.go
+++ b/internal/pkg/crawl/utils.go
@@ -78,10 +78,16 @@ func extractLinksFromText(source string) (links []*url.URL) {
 	return links
 }
 
-// TODO: re-implement host limitation
-// func (c *Crawl) shouldPause(host string) bool {
-// 	return c.Frontier.GetActiveHostCount(host) >= c.MaxConcurrentRequestsPerDomain
-// }
+// Re-implement host limitation
+func (c *Crawl) shouldPause(host string) bool {
+	activeHostCount := c.Frontier.GetActiveHostCount(host)
+	if activeHostCount >= c.MaxConcurrentRequestsPerDomain {
+		logrus.Warnf("Pausing crawl for host %s: active requests (%d) exceed limit (%d)", 
+			host, activeHostCount, c.MaxConcurrentRequestsPerDomain)
+		return true
+	}
+	return false
+}
 
 func isStatusCodeRedirect(statusCode int) bool {
 	if statusCode == 300 || statusCode == 301 ||


### PR DESCRIPTION
This pull request includes  improvements to asset processing in the `captureAssets` function, and enhancements to video extraction for multiple platforms. Additionally, it re-implements host limitation during crawling.


### Asset processing improvements:

* `internal/pkg/crawl/assets.go`: Implemented and decremented a counter for the number of assets currently being processed in `captureAssets` function.

### Video extraction enhancements:

* `internal/pkg/crawl/capture.go`: Added support for Vimeo and Dailymotion watch pages in addition to YouTube.

### Host limitation re-implementation:

* `internal/pkg/crawl/utils.go`: Re-implemented host limitation to pause crawling when active requests exceed the limit.