### PR TITLE
Enhance base URL handling

### DIFF
--- a/internal/pkg/postprocessor/extractor/base.go
+++ b/internal/pkg/postprocessor/extractor/base.go
@@ -1,13 +1,47 @@
 package extractor
 
 import (
+	"net/url"
+	"strings"
+
 	"github.com/PuerkitoBio/goquery"
+	"github.com/internetarchive/Zeno/internal/pkg/log"
 	"github.com/internetarchive/Zeno/pkg/models"
 )
 
+var basetagLogger = log.NewFieldedLogger(&log.Fields{
+	"component": "postprocessor.extractor.base",
+})
+
+// extract document <base> tag and set the base URL for item if it's valid
 func extractBaseTag(item *models.Item, doc *goquery.Document) {
+	// spec ref: https://html.spec.whatwg.org/multipage/semantics.html#the-base-element
 	base, exists := doc.Find("base").First().Attr("href")
-	if exists {
-		item.SetBase(base)
+	if !exists {
+		return
 	}
+
+	// https://html.spec.whatwg.org/multipage/urls-and-fetching.html#valid-url-potentially-surrounded-by-spaces
+	// > The href content attribute, if specified, must contain a valid URL potentially surrounded by spaces.
+	// > A string is a valid URL potentially surrounded by spaces if, after stripping leading and trailing ASCII whitespace from it, it is a valid URL string.
+	// > ASCII whitespace is U+0009 TAB, U+000A LF, U+000C FF, U+000D CR, or U+0020 SPACE.
+	//
+	// We don't use strings.TrimSpace() here because it trim unicode spaces as well.
+	base = strings.Trim(base, "\t\n\f\r ")
+
+	baseURL, err := url.Parse(base)
+	if err != nil {
+		basetagLogger.Error("unable to parse base url", "error", err, "base", base)
+		return
+	}
+
+	if baseURL.Scheme == "data" || baseURL.Scheme == "javascript" {
+		basetagLogger.Error("the base url has the bad scheme", "base", base, "scheme", baseURL.Scheme)
+		return
+	}
+
+	fallbackBaseURL := item.GetURL().GetParsed()
+	newResolvedBaseURL := fallbackBaseURL.ResolveReference(baseURL)
+
+	item.SetBase(newResolvedBaseURL)
 }

--- a/internal/pkg/postprocessor/extractor/base_test.go
+++ b/internal/pkg/postprocessor/extractor/base_test.go
@@ -4,34 +4,30 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/internetarchive/Zeno/pkg/models"
 	"github.com/PuerkitoBio/goquery"
+	"github.com/internetarchive/Zeno/pkg/models"
 )
 
-func TestExtractBaseTag(t *testing.T) {
-	htmlString := `
-	<!DOCTYPE html>
-	<html>
-	<head>
-		<title>Test Page</title>
-		<base href="http://example.com/something/"
-	</head>
-	<body>
-		<p>First paragraph</p>
-	</body>
-	</html>`
-	doc, err := goquery.NewDocumentFromReader(strings.NewReader(htmlString))
+func newDocumentWithBaseTag(base string) *goquery.Document {
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(`<html><head><base href="PLACEHOLDER" target="_blank"></head><body></body></html>`))
 	if err != nil {
-		t.Errorf("html doc loading failed %s", err)
+		panic(err)
 	}
+	doc.Find("base").First().SetAttr("href", base)
+
+	return doc
+}
+
+func TestExtractBaseTag(t *testing.T) {
+	doc := newDocumentWithBaseTag("http://example.com/something/")
 
 	item := models.NewItem("test", &models.URL{
-    Raw: "https://example.com/something/page.html",
-  }, "")
+		Raw: "https://example.com/something/page.html",
+	}, "")
 
 	extractBaseTag(item, doc)
 
-	if item.GetBase() != "http://example.com/something/" {
+	if item.GetBase().String() != "http://example.com/something/" {
 		t.Errorf("Cannot find html doc base.href")
 	}
 }

--- a/internal/pkg/postprocessor/extractor/html.go
+++ b/internal/pkg/postprocessor/extractor/html.go
@@ -89,7 +89,7 @@ func HTMLOutlinks(item *models.Item) (outlinks []*models.URL, err error) {
 		}
 
 		// Discard URLs that are the same as the base URL or the current URL
-		if rawOutlink == item.GetBase() || rawOutlink == item.GetURL().String() {
+		if (item.GetBase() != nil && rawOutlink == item.GetBase().String()) || rawOutlink == item.GetURL().String() {
 			logger.Debug("discarding outlink because it is the same as the base URL or current URL", "url", rawOutlink, "item", item.GetShortID())
 			continue
 		}
@@ -378,6 +378,16 @@ func HTMLAssets(item *models.Item) (assets []*models.URL, err error) {
 	}
 
 	for _, rawAsset := range rawAssets {
+		resolvedURL, err := resolveURL(rawAsset, item)
+		if err != nil {
+			logger.Debug("unable to resolve URL", "error", err, "url", item.GetURL().String(), "item", item.GetShortID())
+		} else if resolvedURL != "" {
+			assets = append(assets, &models.URL{
+				Raw: resolvedURL,
+			})
+			continue
+		}
+
 		assets = append(assets, &models.URL{
 			Raw: rawAsset,
 		})

--- a/internal/pkg/postprocessor/extractor/resolve.go
+++ b/internal/pkg/postprocessor/extractor/resolve.go
@@ -13,15 +13,10 @@ import (
 func resolveURL(URL string, item *models.Item) (absolute string, err error) {
 	// Determine the base URL.
 	var baseURL *url.URL
-	if item.GetBase() == "" {
-		// If no base is provided, use the parent URL.
+	if item.GetBase() == nil { // If no base is provided, use the parent URL.
 		baseURL = item.GetURL().GetParsed()
 	} else {
-		// Parse the provided base.
-		baseURL, err = url.Parse(item.GetBase())
-		if err != nil {
-			return "", fmt.Errorf("invalid base URL %s: %w", item.GetBase(), err)
-		}
+		baseURL = item.GetBase()
 	}
 
 	// Parse the URL to resolve.

--- a/internal/pkg/postprocessor/extractor/resolve_test.go
+++ b/internal/pkg/postprocessor/extractor/resolve_test.go
@@ -117,7 +117,6 @@ func TestResolveURL(t *testing.T) {
 			item := models.NewItem("test", &models.URL{
 				Raw: tt.parentURL,
 			}, "")
-			item.GetURL().Parse()
 
 			var doc *goquery.Document
 			if tt.base != "" {

--- a/pkg/models/item.go
+++ b/pkg/models/item.go
@@ -3,6 +3,7 @@ package models
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"strings"
 	"sync"
 
@@ -17,7 +18,7 @@ type Item struct {
 	seedVia    string       // SeedVia is the source of the seed (shoud not be used for non-seeds)
 	status     ItemState    // Status is the state of the item in the pipeline
 	source     ItemSource   // Source is the source of the item in the pipeline
-	base       string       // Base is the base URL of the item, extracted from a <base> tag
+	base       *url.URL     // Base is the base URL of the item, extracted from a <base> tag
 	childrenMu sync.RWMutex // Mutex to protect the children slice
 	children   []*Item      // Children is a slice of Item created from this item
 	parent     *Item        // Parent is the parent of the item (will be nil if the item is a seed)
@@ -174,7 +175,7 @@ func (i *Item) GetStatus() ItemState { return i.status }
 func (i *Item) GetSource() ItemSource { return i.source }
 
 // GetBase returns the base URL of the item
-func (i *Item) GetBase() string { return i.base }
+func (i *Item) GetBase() *url.URL { return i.base }
 
 // GetMaxDepth returns the maxDepth of the item by traversing the tree
 func (i *Item) GetMaxDepth() int64 {
@@ -293,7 +294,7 @@ func (i *Item) SetSource(source ItemSource) error {
 }
 
 // SetBase sets the base URL of the item
-func (i *Item) SetBase(base string) { i.base = base }
+func (i *Item) SetBase(base *url.URL) { i.base = base }
 
 // SetError sets the error of the item
 func (i *Item) SetError(err error) { i.err = err }


### PR DESCRIPTION
- Enhance `extractBaseTag()` function to conform with whatwg's spec: <https://html.spec.whatwg.org/multipage/semantics.html#the-base-element>
- Change base URL type in Item model from `string` to `*url.URL` for convenience.
- Make `HTMLAssets()` resolve URLs directly in `html.go`, just like `HTMLOutlinks()`.