### PR TITLE
Optimize the OSS extraction process and implement Azure Blob extractor

### DIFF
--- a/internal/pkg/postprocessor/extractor/object_storage.go
+++ b/internal/pkg/postprocessor/extractor/object_storage.go
@@ -1,6 +1,7 @@
 package extractor
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/internetarchive/Zeno/internal/pkg/utils"
@@ -30,6 +31,6 @@ func ObjectStorage(URL *models.URL) ([]*models.URL, error) {
 	} else if utils.StringContainsSliceElements(server, azureServers) {
 		return azure(URL)
 	} else {
-		return nil, nil
+		return nil, fmt.Errorf("unknown object storage server: %s", server)
 	}
 }

--- a/internal/pkg/postprocessor/extractor/object_storage.go
+++ b/internal/pkg/postprocessor/extractor/object_storage.go
@@ -1,0 +1,35 @@
+package extractor
+
+import (
+	"strings"
+
+	"github.com/internetarchive/Zeno/internal/pkg/utils"
+	"github.com/internetarchive/Zeno/pkg/models"
+)
+
+// All the supported object storage servers
+var ObjectStorageServers = func() (s []string) {
+	s = append(s, s3CompatibleServers...)
+	s = append(s, azureServers...)
+	return s
+}()
+
+// IsObjectStorage checks if the response is from an object storage server
+func IsObjectStorage(URL *models.URL) bool {
+	return utils.StringContainsSliceElements(URL.GetResponse().Header.Get("Server"), ObjectStorageServers) &&
+		strings.Contains(URL.GetResponse().Header.Get("Content-Type"), "/xml") // tricky match both application/xml and text/xml
+}
+
+// ObjectStorage decides which helper to call based on the object storage server
+func ObjectStorage(URL *models.URL) ([]*models.URL, error) {
+	defer URL.RewindBody()
+
+	server := URL.GetResponse().Header.Get("Server")
+	if utils.StringContainsSliceElements(server, s3CompatibleServers) {
+		return s3Compatible(URL)
+	} else if utils.StringContainsSliceElements(server, azureServers) {
+		return azure(URL)
+	} else {
+		return nil, nil
+	}
+}

--- a/internal/pkg/postprocessor/extractor/object_storage.go
+++ b/internal/pkg/postprocessor/extractor/object_storage.go
@@ -18,7 +18,7 @@ var ObjectStorageServers = func() (s []string) {
 // IsObjectStorage checks if the response is from an object storage server
 func IsObjectStorage(URL *models.URL) bool {
 	return utils.StringContainsSliceElements(URL.GetResponse().Header.Get("Server"), ObjectStorageServers) &&
-		strings.Contains(URL.GetResponse().Header.Get("Content-Type"), "/xml") // tricky match both application/xml and text/xml
+		strings.Contains(strings.ToLower(URL.GetResponse().Header.Get("Content-Type")), "/xml") // tricky match both application/xml and text/xml
 }
 
 // ObjectStorage decides which helper to call based on the object storage server

--- a/internal/pkg/postprocessor/extractor/object_storage_azure.go
+++ b/internal/pkg/postprocessor/extractor/object_storage_azure.go
@@ -40,7 +40,7 @@ func azure(URL *models.URL) ([]*models.URL, error) {
 	// Decode XML result
 	var result AZureBlobEnumerationResults
 	if err := xml.NewDecoder(URL.GetBody()).Decode(&result); err != nil {
-		return nil, fmt.Errorf("error decoding S3 XML: %w", err)
+		return nil, fmt.Errorf("error decoding AZureBlobEnumerationResults XML: %w", err)
 	}
 
 	reqURL := URL.GetRequest().URL

--- a/internal/pkg/postprocessor/extractor/object_storage_azure.go
+++ b/internal/pkg/postprocessor/extractor/object_storage_azure.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/internetarchive/Zeno/internal/pkg/log"
 	"github.com/internetarchive/Zeno/pkg/models"
 )
 
@@ -33,6 +34,10 @@ type AZureBlob struct {
 	LastModified string `xml:"Properties>Last-Modified"`
 	Size         int64  `xml:"Properties>Content-Length"`
 }
+
+var azureLogger = log.NewFieldedLogger(&log.Fields{
+	"component": "postprocessor.extractor.object_storage_azure",
+})
 
 func azure(URL *models.URL) ([]*models.URL, error) {
 	defer URL.RewindBody()
@@ -70,7 +75,8 @@ func azure(URL *models.URL) ([]*models.URL, error) {
 	for _, blob := range result.Blobs {
 		fileURL := baseURL
 		if strings.HasPrefix(blob.Name, "/") {
-			panic("TODO")
+			azureLogger.Warn("invalid blob name: it starts with a leading slash", "blob_name", blob.Name)
+			continue
 		}
 		fileURL.Path = baseURL.Path + blob.Name
 		outlinks = append(outlinks, fileURL.String())

--- a/internal/pkg/postprocessor/extractor/object_storage_azure.go
+++ b/internal/pkg/postprocessor/extractor/object_storage_azure.go
@@ -61,24 +61,16 @@ func azure(URL *models.URL) ([]*models.URL, error) {
 	}
 
 	// Build base url for files
-	//
-	// reqURL: "https://{endpoint_host}/{account}/{bucket}?..."
-	// ->
-	// baseURL: "https://{endpoint_host}/{account}/{bucket}/
 	baseURL := *reqURL
 	baseURL.RawQuery = ""
 	baseURL.ForceQuery = false
-	if !strings.HasSuffix(baseURL.Path, "/") {
-		baseURL.Path = baseURL.Path + "/"
-	}
 
 	for _, blob := range result.Blobs {
-		fileURL := baseURL
 		if strings.HasPrefix(blob.Name, "/") {
 			azureLogger.Warn("invalid blob name: it starts with a leading slash", "blob_name", blob.Name)
 			continue
 		}
-		fileURL.Path = baseURL.Path + blob.Name
+		fileURL := baseURL.JoinPath(blob.Name)
 		outlinks = append(outlinks, fileURL.String())
 	}
 

--- a/internal/pkg/postprocessor/extractor/object_storage_azure.go
+++ b/internal/pkg/postprocessor/extractor/object_storage_azure.go
@@ -1,0 +1,80 @@
+package extractor
+
+import (
+	"encoding/xml"
+	"fmt"
+	"strings"
+
+	"github.com/internetarchive/Zeno/pkg/models"
+)
+
+// Azure Blob Storage
+var azureServers = []string{
+	// Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+	"Windows-Azure-Blob",
+	// Blob Service Version 1.0 Microsoft-HTTPAPI/2.0
+	"Blob Service Version",
+	// emulator, https://github.com/Azure/Azurite
+	"Azurite-Blob",
+}
+
+// AZureBlobEnumerationResults represents the XML structure of an AZure Blob Storage listing
+// <https://learn.microsoft.com/en-us/rest/api/storageservices/enumerating-blob-resources>
+type AZureBlobEnumerationResults struct {
+	XMLName    xml.Name    `xml:"EnumerationResults"`
+	Prefix     string      `xml:"Prefix"`
+	Marker     string      `xml:"Marker"`
+	Blobs      []AZureBlob `xml:"Blobs>Blob"`
+	NextMarker string      `xml:"NextMarker"`
+}
+
+type AZureBlob struct {
+	Name         string `xml:"Name"` // path/to/file.txt, no leading slash
+	LastModified string `xml:"Properties>Last-Modified"`
+	Size         int64  `xml:"Properties>Content-Length"`
+}
+
+func azure(URL *models.URL) ([]*models.URL, error) {
+	defer URL.RewindBody()
+
+	// Decode XML result
+	var result AZureBlobEnumerationResults
+	if err := xml.NewDecoder(URL.GetBody()).Decode(&result); err != nil {
+		return nil, fmt.Errorf("error decoding S3 XML: %w", err)
+	}
+
+	reqURL := URL.GetRequest().URL
+
+	var outlinks []string
+
+	if result.NextMarker != "" {
+		nextURL := *reqURL
+		q := nextURL.Query()
+		q.Set("marker", result.NextMarker)
+		nextURL.RawQuery = q.Encode()
+		outlinks = append(outlinks, nextURL.String())
+	}
+
+	// Build base url for files
+	//
+	// reqURL: "https://{endpoint_host}/{account}/{bucket}?..."
+	// ->
+	// baseURL: "https://{endpoint_host}/{account}/{bucket}/
+	baseURL := *reqURL
+	baseURL.RawQuery = ""
+	baseURL.ForceQuery = false
+	if !strings.HasSuffix(baseURL.Path, "/") {
+		baseURL.Path = baseURL.Path + "/"
+	}
+
+	for _, blob := range result.Blobs {
+		fileURL := baseURL
+		if strings.HasPrefix(blob.Name, "/") {
+			panic("TODO")
+		}
+		fileURL.Path = baseURL.Path + blob.Name
+		outlinks = append(outlinks, fileURL.String())
+	}
+
+	return toURLs(outlinks), nil
+}

--- a/internal/pkg/postprocessor/extractor/object_storage_azure.go
+++ b/internal/pkg/postprocessor/extractor/object_storage_azure.go
@@ -19,17 +19,17 @@ var azureServers = []string{
 	"Azurite-Blob",
 }
 
-// AZureBlobEnumerationResults represents the XML structure of an AZure Blob Storage listing
+// AzureBlobEnumerationResults represents the XML structure of an Azure Blob Storage listing
 // <https://learn.microsoft.com/en-us/rest/api/storageservices/enumerating-blob-resources>
-type AZureBlobEnumerationResults struct {
+type AzureBlobEnumerationResults struct {
 	XMLName    xml.Name    `xml:"EnumerationResults"`
 	Prefix     string      `xml:"Prefix"`
 	Marker     string      `xml:"Marker"`
-	Blobs      []AZureBlob `xml:"Blobs>Blob"`
+	Blobs      []AzureBlob `xml:"Blobs>Blob"`
 	NextMarker string      `xml:"NextMarker"`
 }
 
-type AZureBlob struct {
+type AzureBlob struct {
 	Name         string `xml:"Name"` // path/to/file.txt, no leading slash
 	LastModified string `xml:"Properties>Last-Modified"`
 	Size         int64  `xml:"Properties>Content-Length"`
@@ -43,9 +43,9 @@ func azure(URL *models.URL) ([]*models.URL, error) {
 	defer URL.RewindBody()
 
 	// Decode XML result
-	var result AZureBlobEnumerationResults
+	var result AzureBlobEnumerationResults
 	if err := xml.NewDecoder(URL.GetBody()).Decode(&result); err != nil {
-		return nil, fmt.Errorf("error decoding AZureBlobEnumerationResults XML: %w", err)
+		return nil, fmt.Errorf("error decoding AzureBlobEnumerationResults XML: %w", err)
 	}
 
 	reqURL := URL.GetRequest().URL

--- a/internal/pkg/postprocessor/extractor/object_storage_azure_test.go
+++ b/internal/pkg/postprocessor/extractor/object_storage_azure_test.go
@@ -66,9 +66,9 @@ func TestAzure(t *testing.T) {
 		if err == nil {
 			t.Fatalf("expected error for invalid XML, got none")
 		}
-		// "error decoding AZureBlobEnumerationResults XML"
-		if !strings.Contains(err.Error(), "error decoding AZureBlobEnumerationResults XML") {
-			t.Fatalf("expected error 'error decoding AZureBlobEnumerationResults XML', got %v", err)
+
+		if !strings.Contains(err.Error(), "error decoding AzureBlobEnumerationResults XML") {
+			t.Fatalf("expected error 'error decoding AzureBlobEnumerationResults XML', got %v", err)
 		}
 	})
 }

--- a/internal/pkg/postprocessor/extractor/object_storage_azure_test.go
+++ b/internal/pkg/postprocessor/extractor/object_storage_azure_test.go
@@ -1,0 +1,74 @@
+package extractor
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestAzure(t *testing.T) {
+	t.Run("Valid XML with single object and nextMarker", func(t *testing.T) {
+		xmlBody := `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<EnumerationResults  ContainerName="zeno">
+    <Prefix />
+    <Marker>dir/azure_files/test_10.txt</Marker>
+    <MaxResults>1</MaxResults>
+    <Blobs>
+        <Blob>
+            <Name>dir/azure_files/test_100.txt</Name>
+            <Properties>
+                <Creation-Time>Thu, 15 May 2025 08:02:20 GMT</Creation-Time>
+                <Last-Modified>Thu, 15 May 2025 08:02:20 GMT</Last-Modified>
+                <Etag>0x202A0424CF3AFA0</Etag>
+                <Content-Length>4</Content-Length>
+                <Content-Type>text/plain</Content-Type>
+                <Content-MD5>kZ0ReVbTE1xMaD/wITUvXA==</Content-MD5>
+                <BlobType>BlockBlob</BlobType>
+                <LeaseStatus>unlocked</LeaseStatus>
+                <LeaseState>available</LeaseState>
+                <ServerEncrypted>true</ServerEncrypted>
+                <AccessTier>Hot</AccessTier>
+                <AccessTierInferred>true</AccessTierInferred>
+                <AccessTierChangeTime>Thu, 15 May 2025 08:02:20 GMT</AccessTierChangeTime>
+            </Properties>
+        </Blob>
+    </Blobs>
+    <NextMarker>dir/azure_files/test_100.txt</NextMarker>
+</EnumerationResults>`
+		URLObj := buildTestObjectStorageURLObj("http://example.com/devstoreaccount1/zeno?restype=container&comp=list&maxresults=1", xmlBody, http.Header{"Server": []string{"Windows-Azure-Blob/1.0"}})
+		outlinks, err := azure(URLObj)
+		outlinks2, err2 := ObjectStorage(URLObj) // indirectly call, for coverage testing
+		if err != nil || err2 != nil {
+			t.Fatalf("azure() returned unexpected error: %v, err2: %v", err, err2)
+		}
+
+		if len(outlinks) != 2 || len(outlinks2) != 2 {
+			t.Fatalf("expected 2 outlinks, got %d and %d", len(outlinks), len(outlinks2))
+		}
+
+		expectedOutlinks := []string{
+			"http://example.com/devstoreaccount1/zeno?comp=list&marker=dir%2Fazure_files%2Ftest_100.txt&maxresults=1&restype=container",
+			"http://example.com/devstoreaccount1/zeno/dir/azure_files/test_100.txt",
+		}
+
+		for i, outlink := range outlinks {
+			outlink.Parse()
+			if outlink.String() != expectedOutlinks[i] {
+				t.Errorf("expected %s, got %s", expectedOutlinks[i], outlink.String())
+			}
+		}
+	})
+
+	t.Run("invalid XML", func(t *testing.T) {
+		xmlBody := `<EnumerationResults><BadTag`
+		URLObj := buildTestObjectStorageURLObj("http://example.com/devstoreaccount1/zeno?restype=container&comp=list&maxresults=1", xmlBody, http.Header{"Server": []string{"Windows-Azure-Blob/1.0"}})
+		_, err := azure(URLObj)
+		if err == nil {
+			t.Fatalf("expected error for invalid XML, got none")
+		}
+		// "error decoding AZureBlobEnumerationResults XML"
+		if !strings.Contains(err.Error(), "error decoding AZureBlobEnumerationResults XML") {
+			t.Fatalf("expected error 'error decoding AZureBlobEnumerationResults XML', got %v", err)
+		}
+	})
+}

--- a/internal/pkg/postprocessor/extractor/object_storage_s3_test.go
+++ b/internal/pkg/postprocessor/extractor/object_storage_s3_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestS3(t *testing.T) {
+func TestS3Compatible(t *testing.T) {
 	// This subtest shows a scenario of a valid XML with a single object,
 	// and list-type != 2 => "marker" logic should be used.
 	t.Run("Valid XML with single object, no list-type=2 => marker next link", func(t *testing.T) {
@@ -22,12 +22,13 @@ func TestS3(t *testing.T) {
 
 		URLObj := buildTestObjectStorageURLObj("https://example.com/?someparam=1", xmlBody, http.Header{"Server": []string{"AmazonS3"}})
 		outlinks, err := s3Compatible(URLObj)
-		if err != nil {
-			t.Fatalf("S3() returned unexpected error: %v", err)
+		outlinks2, err2 := ObjectStorage(URLObj) // indirectly call, for coverage testing
+		if err != nil || err2 != nil {
+			t.Fatalf("S3() returned unexpected error: %v, err2: %v", err, err2)
 		}
 
-		if len(outlinks) != 2 {
-			t.Fatalf("expected 2 outlinks, got %d", len(outlinks))
+		if len(outlinks) != 2 || len(outlinks2) != 2 {
+			t.Fatalf("expected 2 outlinks, got %d and %d", len(outlinks), len(outlinks2))
 		}
 		expectedOutlinks := []string{
 			"https://example.com/?marker=file1.txt&someparam=1",
@@ -53,13 +54,15 @@ func TestS3(t *testing.T) {
 
 		URLObj := buildTestObjectStorageURLObj("https://example.com/?list-type=2", xmlBody, http.Header{"Server": []string{"AmazonS3"}})
 		outlinks, err := s3Compatible(URLObj)
-		if err != nil {
-			t.Fatalf("S3() returned unexpected error: %v", err)
+		outlinks2, err2 := ObjectStorage(URLObj) // indirectly call, for coverage testing
+		if err != nil || err2 != nil {
+			t.Fatalf("s3Compatible() returned unexpected error: %v, err2: %v", err, err2)
 		}
 
-		if len(outlinks) != 2 {
-			t.Fatalf("expected 2 outlinks, got %d", len(outlinks))
+		if len(outlinks) != 2 || len(outlinks2) != 2 {
+			t.Fatalf("expected 2 outlinks, got %d and %d", len(outlinks), len(outlinks2))
 		}
+
 		if !strings.Contains(outlinks[0].Raw, "prefix=folder1%2F") {
 			t.Errorf("expected prefix=folder1/ in outlink, got %s", outlinks[0].Raw)
 		}
@@ -74,12 +77,13 @@ func TestS3(t *testing.T) {
 
 		URLObj := buildTestObjectStorageURLObj("https://example.com/?list-type=2", xmlBody, http.Header{"Server": []string{"AmazonS3"}})
 		outlinks, err := s3Compatible(URLObj)
-		if err == nil {
+		outlinks2, err2 := ObjectStorage(URLObj) // indirectly call, for coverage testing
+		if err == nil || err2 == nil {
 			t.Fatalf("expected error for invalid XML, got none")
 		}
 
-		if len(outlinks) != 0 {
-			t.Errorf("expected no outlinks on error, got %v", outlinks)
+		if len(outlinks) != 0 || len(outlinks2) != 0 {
+			t.Errorf("expected no outlinks on error, got %d and %d", len(outlinks), len(outlinks2))
 		}
 	})
 }

--- a/internal/pkg/postprocessor/extractor/object_storage_s3_test.go
+++ b/internal/pkg/postprocessor/extractor/object_storage_s3_test.go
@@ -11,40 +11,6 @@ import (
 	"github.com/internetarchive/gowarc/pkg/spooledtempfile"
 )
 
-// TestIsS3 checks the Server header for known S3 strings.
-func TestIsS3(t *testing.T) {
-	tests := []struct {
-		name   string
-		server string
-		want   bool
-	}{
-		{"AmazonS3", "AmazonS3", true},
-		{"WasabiS3", "WasabiS3", true},
-		{"AliyunOSS", "AliyunOSS", true},
-		{"No match", "Apache", false},
-		{"Partial match", "Amazon", false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Create a *models.URL with the response Server header set
-			URLObj := &models.URL{}
-
-			URLObj.SetResponse(&http.Response{
-				Header: http.Header{
-					"Server":       []string{tt.server},
-					"Content-Type": []string{"text/xml"},
-				},
-			})
-
-			got := IsS3(URLObj)
-			if got != tt.want {
-				t.Errorf("IsS3(server=%q) = %v, want %v", tt.server, got, tt.want)
-			}
-		})
-	}
-}
-
 func TestS3(t *testing.T) {
 	// This subtest shows a scenario of a valid XML with a single object,
 	// and list-type != 2 => "marker" logic should be used.
@@ -79,7 +45,7 @@ func TestS3(t *testing.T) {
 
 		URLObj.SetBody(spooledTempFile)
 
-		outlinks, err := S3(URLObj)
+		outlinks, err := s3Compatible(URLObj)
 		if err != nil {
 			t.Fatalf("S3() returned unexpected error: %v", err)
 		}
@@ -124,7 +90,7 @@ func TestS3(t *testing.T) {
 
 		URLObj.SetBody(spooledTempFile)
 
-		outlinks, err := S3(URLObj)
+		outlinks, err := s3Compatible(URLObj)
 		if err != nil {
 			t.Fatalf("S3() returned unexpected error: %v", err)
 		}
@@ -159,7 +125,7 @@ func TestS3(t *testing.T) {
 
 		URLObj.SetBody(spooledTempFile)
 
-		outlinks, err := S3(URLObj)
+		outlinks, err := s3Compatible(URLObj)
 		if err == nil {
 			t.Fatalf("expected error for invalid XML, got none")
 		}

--- a/internal/pkg/postprocessor/extractor/object_storage_s3_test.go
+++ b/internal/pkg/postprocessor/extractor/object_storage_s3_test.go
@@ -2,13 +2,8 @@ package extractor
 
 import (
 	"net/http"
-	"net/url"
-	"os"
 	"strings"
 	"testing"
-
-	"github.com/internetarchive/Zeno/pkg/models"
-	"github.com/internetarchive/gowarc/pkg/spooledtempfile"
 )
 
 func TestS3(t *testing.T) {
@@ -25,26 +20,7 @@ func TestS3(t *testing.T) {
 	<IsTruncated>false</IsTruncated>
 </ListBucketResult>`
 
-		// Build an http.Request with a query param that is NOT list-type=2
-		reqURL, _ := url.Parse("https://example.com/?someparam=1")
-
-		// Create your models.URL instance.
-		URLObj := &models.URL{}
-		URLObj.SetRequest(&http.Request{URL: reqURL})
-
-		// Likewise, set the HTTP response header using SetResponse.
-		// We want to simulate an S3 server for these tests.
-		URLObj.SetResponse(&http.Response{
-			Header: http.Header{
-				"Server": []string{"AmazonS3"},
-			},
-		})
-
-		spooledTempFile := spooledtempfile.NewSpooledTempFile("test", os.TempDir(), 2048, false, -1)
-		spooledTempFile.Write([]byte(xmlBody))
-
-		URLObj.SetBody(spooledTempFile)
-
+		URLObj := buildTestObjectStorageURLObj("https://example.com/?someparam=1", xmlBody, http.Header{"Server": []string{"AmazonS3"}})
 		outlinks, err := s3Compatible(URLObj)
 		if err != nil {
 			t.Fatalf("S3() returned unexpected error: %v", err)
@@ -75,21 +51,7 @@ func TestS3(t *testing.T) {
     </CommonPrefixes>
 </ListBucketResult>`
 
-		reqURL, _ := url.Parse("https://example.com/?list-type=2")
-
-		URLObj := &models.URL{}
-		URLObj.SetRequest(&http.Request{URL: reqURL})
-		URLObj.SetResponse(&http.Response{
-			Header: http.Header{
-				"Server": []string{"AmazonS3"},
-			},
-		})
-
-		spooledTempFile := spooledtempfile.NewSpooledTempFile("test", os.TempDir(), 2048, false, -1)
-		spooledTempFile.Write([]byte(xmlBody))
-
-		URLObj.SetBody(spooledTempFile)
-
+		URLObj := buildTestObjectStorageURLObj("https://example.com/?list-type=2", xmlBody, http.Header{"Server": []string{"AmazonS3"}})
 		outlinks, err := s3Compatible(URLObj)
 		if err != nil {
 			t.Fatalf("S3() returned unexpected error: %v", err)
@@ -110,21 +72,7 @@ func TestS3(t *testing.T) {
 	t.Run("Invalid XML => error", func(t *testing.T) {
 		xmlBody := `<ListBucketResult><BadTag`
 
-		reqURL, _ := url.Parse("https://example.com/?list-type=2")
-
-		URLObj := &models.URL{}
-		URLObj.SetRequest(&http.Request{URL: reqURL})
-		URLObj.SetResponse(&http.Response{
-			Header: http.Header{
-				"Server": []string{"AmazonS3"},
-			},
-		})
-
-		spooledTempFile := spooledtempfile.NewSpooledTempFile("test", os.TempDir(), 2048, false, -1)
-		spooledTempFile.Write([]byte(xmlBody))
-
-		URLObj.SetBody(spooledTempFile)
-
+		URLObj := buildTestObjectStorageURLObj("https://example.com/?list-type=2", xmlBody, http.Header{"Server": []string{"AmazonS3"}})
 		outlinks, err := s3Compatible(URLObj)
 		if err == nil {
 			t.Fatalf("expected error for invalid XML, got none")

--- a/internal/pkg/postprocessor/extractor/object_storage_test.go
+++ b/internal/pkg/postprocessor/extractor/object_storage_test.go
@@ -2,10 +2,34 @@ package extractor
 
 import (
 	"net/http"
+	"net/url"
+	"os"
 	"testing"
 
 	"github.com/internetarchive/Zeno/pkg/models"
+	"github.com/internetarchive/gowarc/pkg/spooledtempfile"
 )
+
+func buildTestObjectStorageURLObj(selfURL, xmlBody string, respHeader http.Header) *models.URL {
+	urlURL, err := url.Parse(selfURL)
+	if err != nil {
+		panic(err)
+	}
+
+	URL := &models.URL{}
+	URL.SetRequest(&http.Request{URL: urlURL})
+
+	URL.SetResponse(&http.Response{
+		Header: respHeader,
+	})
+
+	spooledTempFile := spooledtempfile.NewSpooledTempFile("test", os.TempDir(), 2048, false, -1)
+	spooledTempFile.Write([]byte(xmlBody))
+
+	URL.SetBody(spooledTempFile)
+	URL.Parse()
+	return URL
+}
 
 // TestIsObjectStorage checks the Server header for known OSS Server strings.
 func TestIsObjectStorage(t *testing.T) {

--- a/internal/pkg/postprocessor/extractor/object_storage_test.go
+++ b/internal/pkg/postprocessor/extractor/object_storage_test.go
@@ -1,0 +1,43 @@
+package extractor
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/internetarchive/Zeno/pkg/models"
+)
+
+// TestIsObjectStorage checks the Server header for known OSS Server strings.
+func TestIsObjectStorage(t *testing.T) {
+	tests := []struct {
+		name   string
+		server string
+		want   bool
+	}{
+		{"AmazonS3", "AmazonS3", true},
+		{"WasabiS3", "WasabiS3", true},
+		{"Azurite", "Azurite-Blob/3.34.0", true},
+		{"AliyunOSS", "AliyunOSS", true},
+		{"No match", "Apache", false},
+		{"Partial match", "Amazon", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a *models.URL with the response Server header set
+			URLObj := &models.URL{}
+
+			URLObj.SetResponse(&http.Response{
+				Header: http.Header{
+					"Server":       []string{tt.server},
+					"Content-Type": []string{"text/xml"},
+				},
+			})
+
+			got := IsObjectStorage(URLObj)
+			if got != tt.want {
+				t.Errorf("IsObjectStorage(server=%q) = %v, want %v", tt.server, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/pkg/postprocessor/extractor/object_storage_test.go
+++ b/internal/pkg/postprocessor/extractor/object_storage_test.go
@@ -65,3 +65,20 @@ func TestIsObjectStorage(t *testing.T) {
 		})
 	}
 }
+
+func TestObjectStorage(t *testing.T) {
+	t.Run("Unknown object storage server", func(t *testing.T) {
+		xmlBody := `<Placeholder>XML</Placeholder>`
+
+		URLObj := buildTestObjectStorageURLObj("https://example.com/", xmlBody, http.Header{"Server": []string{"NotAnOSS"}})
+		_, err := ObjectStorage(URLObj)
+
+		if err == nil {
+			t.Fatalf("expected error for unknown object storage server, got none")
+		}
+
+		if err.Error() != "unknown object storage server: NotAnOSS" {
+			t.Fatalf("expected error 'unknown object storage server: NotAnOSS', got %v", err)
+		}
+	})
+}

--- a/internal/pkg/postprocessor/extractor/utils.go
+++ b/internal/pkg/postprocessor/extractor/utils.go
@@ -60,7 +60,7 @@ func sortURLs(urls []*models.URL) {
 
 // Convert from []string -> []*models.URL
 func toURLs(s []string) []*models.URL {
-	var outlinks []*models.URL
+	outlinks := make([]*models.URL, 0, len(s))
 	for _, link := range s {
 		outlinks = append(outlinks, &models.URL{Raw: link})
 	}

--- a/internal/pkg/postprocessor/extractor/utils.go
+++ b/internal/pkg/postprocessor/extractor/utils.go
@@ -57,3 +57,12 @@ func sortURLs(urls []*models.URL) {
 		return urls[i].Raw < urls[j].Raw
 	})
 }
+
+// Convert from []string -> []*models.URL
+func toURLs(s []string) []*models.URL {
+	var outlinks []*models.URL
+	for _, link := range s {
+		outlinks = append(outlinks, &models.URL{Raw: link})
+	}
+	return outlinks
+}

--- a/internal/pkg/postprocessor/outlinks.go
+++ b/internal/pkg/postprocessor/outlinks.go
@@ -41,10 +41,10 @@ func extractOutlinks(item *models.Item) (outlinks []*models.URL, err error) {
 			logger.Error("unable to extract outlinks", "extractor", "truthsocial.GenerateOutlinksURLsFromLookup", "err", err.Error(), "item", item.GetShortID(), "url", item.GetURL().String())
 			return outlinks, err
 		}
-	case extractor.IsS3(item.GetURL()):
-		outlinks, err = extractor.S3(item.GetURL())
+	case extractor.IsObjectStorage(item.GetURL()):
+		outlinks, err = extractor.ObjectStorage(item.GetURL())
 		if err != nil {
-			logger.Error("unable to extract outlinks from S3", "extractor", "S3", "err", err.Error(), "item", item.GetShortID(), "url", item.GetURL().String())
+			logger.Error("unable to extract outlinks from ObjectStorage", "extractor", "ObjectStorage", "err", err.Error(), "item", item.GetShortID(), "url", item.GetURL().String())
 			return outlinks, err
 		}
 	case extractor.IsSitemapXML(item.GetURL()):


### PR DESCRIPTION
When fixing #280, I found that Azure Blob is not S3 compatible, so I implemented a separate Azure sub-extractor. Then I thought that one URL can obviously only be one type of OSS, so I created the `ObjectStorage()` method to call the sub-extractor (S3/Azure/...) conditionally.