### PR TITLE
Increase mimetype detection buffer from 2k to 3k

### DIFF
--- a/internal/pkg/archiver/body.go
+++ b/internal/pkg/archiver/body.go
@@ -34,9 +34,10 @@ func ProcessBody(u *models.URL, disableAssetsCapture, domainsCrawl bool, maxHops
 		}
 	}
 
-	// Create a buffer to hold the body (first 2KB)
+	// Create a buffer to hold the body (first 3KB) as suggested by mimetype author
+	// https://github.com/gabriel-vasile/mimetype/blob/66e5c005d80684b64f47eeeb15ad439ee6fad667/mimetype.go#L15
 	buffer := new(bytes.Buffer)
-	if err := copyWithTimeoutN(buffer, u.GetResponse().Body, 2048, conn); err != nil {
+	if err := copyWithTimeoutN(buffer, u.GetResponse().Body, 3072, conn); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
As suggested by the author of the library for better results. https://github.com/gabriel-vasile/mimetype/blob/66e5c005d80684b64f47eeeb15ad439ee6fad667/mimetype.go#L15

It used to be 2k but they increased it to 3k recently.