### PR TITLE
Filter outlinks with unwanted protocols

### DIFF
--- a/internal/pkg/postprocessor/extractor/pdf.go
+++ b/internal/pkg/postprocessor/extractor/pdf.go
@@ -1,8 +1,6 @@
 package extractor
 
 import (
-	"strings"
-
 	"github.com/internetarchive/Zeno/pkg/models"
 
 	pdfapi "github.com/pdfcpu/pdfcpu/pkg/api"
@@ -38,14 +36,6 @@ func PDF(URL *models.URL) (outlinks []*models.URL, err error) {
 			if !ok || link.URI == "" {
 				continue
 			}
-
-			// Skip unwanted URIs
-			if strings.HasPrefix(link.URI, "mailto:") ||
-				strings.HasPrefix(link.URI, "tel:") ||
-				strings.HasPrefix(link.URI, "file:") {
-				continue
-			}
-
 			outlinks = append(outlinks, &models.URL{Raw: link.URI})
 		}
 	}

--- a/internal/pkg/postprocessor/outlinks_test.go
+++ b/internal/pkg/postprocessor/outlinks_test.go
@@ -1,0 +1,22 @@
+package postprocessor
+
+import (
+	"testing"
+
+	"github.com/internetarchive/Zeno/pkg/models"
+)
+
+func TestFilterURLsByProtocol(t *testing.T) {
+	var outlinks []*models.URL
+	outlinks = append(outlinks, &models.URL{Raw: "http://example.com"})
+	// skipped
+	outlinks = append(outlinks, &models.URL{Raw: "tel:12312313"})
+	outlinks = append(outlinks, &models.URL{Raw: "MAILTO:someone@archive.org"})
+	outlinks = append(outlinks, &models.URL{Raw: "file:/tmp/data.dat"})
+
+	filtered := filterURLsByProtocol(outlinks)
+
+	if len(filtered) != 1 {
+		t.Errorf("expected 1 filtered, got %d", len(filtered))
+	}
+}


### PR DESCRIPTION
We filtered some protocols only in the PDF outlink extractor. We didn't catch uppercase and we were missing a lot of protocols.

We implement a common filter function that applies to all extractors and remove the PDF specific code.

We also add a unit test.