### PR TITLE
Make terminal logging colorful 🌈

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -44,6 +44,7 @@ func Run() error {
 	rootCmd.PersistentFlags().String("config-file", "", "config file (default is $HOME/zeno-config.yaml)")
 	rootCmd.PersistentFlags().Bool("no-stdout-log", false, "disable stdout logging.")
 	rootCmd.PersistentFlags().Bool("no-stderr-log", false, "disable stderr logging.")
+	rootCmd.PersistentFlags().Bool("no-color-logs", false, "switch the terminal (stdout and stderr) logging handler from [slogcolor] handler to the standard [slog] handler (help ensure compatibility with logging collectors)")
 	rootCmd.PersistentFlags().Bool("consul-config", false, "Use this flag to enable consul config support")
 	rootCmd.PersistentFlags().String("consul-address", "", "The consul address used to retreive config")
 	rootCmd.PersistentFlags().String("consul-path", "", "The full Consul K/V path where the config is stored")

--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,12 @@ go 1.24.2
 
 require (
 	github.com/ImVexed/fasturl v0.0.0-20230304231329-4e41488060f3
+	github.com/MatusOllah/slogcolor v1.6.0
 	github.com/PuerkitoBio/goquery v1.10.3
 	github.com/ada-url/goada v0.0.0-20250104020233-00cbf4dc9da1
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/dustin/go-humanize v1.0.1
+	github.com/fatih/color v1.16.0
 	github.com/gabriel-vasile/mimetype v1.4.9
 	github.com/gdamore/tcell/v2 v2.8.1
 	github.com/google/uuid v1.6.0
@@ -38,7 +40,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudflare/circl v1.6.1 // indirect
 	github.com/dolthub/maphash v0.1.0 // indirect
-	github.com/fatih/color v1.16.0 // indirect
 	github.com/fsnotify/fsnotify v1.8.0 // indirect
 	github.com/gammazero/deque v1.0.0 // indirect
 	github.com/gdamore/encoding v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/ImVexed/fasturl v0.0.0-20230304231329-4e41488060f3 h1:ClzzXMDDuUbWfNNZqGeYq4PnYOlwlOVIvSyNaIy0ykg=
 github.com/ImVexed/fasturl v0.0.0-20230304231329-4e41488060f3/go.mod h1:we0YA5CsBbH5+/NUzC/AlMmxaDtWlXeNsqrwXjTzmzA=
+github.com/MatusOllah/slogcolor v1.6.0 h1:JAKer0xj5l1jYTXyQvs5ggqmJqYDuLnxgR9jfMAd+sI=
+github.com/MatusOllah/slogcolor v1.6.0/go.mod h1:5y1H50XuQIBvuYTJlmokWi+4FuPiJN5L7Z0jM4K4bYA=
 github.com/PuerkitoBio/goquery v1.10.3 h1:pFYcNSqHxBD06Fpj/KsbStFRsgRATgnf3LeXiUkhzPo=
 github.com/PuerkitoBio/goquery v1.10.3/go.mod h1:tMUX0zDMHXYlAQk6p35XxQMqMweEKB7iK7iLNd4RH4Y=
 github.com/ada-url/goada v0.0.0-20250104020233-00cbf4dc9da1 h1:K54lYH7ZY/NHweMd9/R82dHaFelQQmwjEhUfwUqCqEk=

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -93,6 +93,7 @@ type Config struct {
 	// Logging
 	NoStdoutLogging  bool   `mapstructure:"no-stdout-log"`
 	NoStderrLogging  bool   `mapstructure:"no-stderr-log"`
+	NoColorLogging   bool   `mapstructure:"no-color-logs"`
 	NoFileLogging    bool   `mapstructure:"no-log-file"`
 	StdoutLogLevel   string `mapstructure:"log-level"`
 	TUI              bool   `mapstructure:"tui"`


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0feac5d5-8e29-4f84-a601-0684dd3fba60)

Now my eyes can easily spot the warn/error logs from the terminal stream.

Also added --no-color-logs flag to disable this feature. (to switch back to [slog] handler)

---

This PR only colors the stdout and stderr terminal logging handlers and does not affect the file logging handler (`/jobs/{job}/log/ZENO-{time}.log`).

---

The [slogcolor] handler's output format is slightly different from slog. For example, it does not escape the `"` to `\"` in the log message.

---

Introduced lib:
- https://github.com/MatusOllah/slogcolor