### PR TITLE
Increase ProcessBody memory buffer from 2 to 32MB

### DIFF
--- a/internal/pkg/archiver/body.go
+++ b/internal/pkg/archiver/body.go
@@ -49,8 +49,8 @@ func ProcessBody(u *models.URL, disableAssetsCapture, domainsCrawl bool, maxHops
 		u.GetMIMEType().Is("application/pdf") ||
 		strings.Contains(u.GetMIMEType().String(), "text/") {
 
-		// Create a temp file with a 2MB memory buffer
-		spooledBuff := spooledtempfile.NewSpooledTempFile("zeno", WARCTempDir, 2097152, false, -1)
+		// Create a temp file with a 32MB memory buffer
+		spooledBuff := spooledtempfile.NewSpooledTempFile("zeno", WARCTempDir, 32000000, false, -1)
 		_, err := io.Copy(spooledBuff, buffer)
 		if err != nil {
 			closeErr := spooledBuff.Close()


### PR DESCRIPTION
Avoid disk I/O for temporary WARC files < 32MB to improve performance.