### PR TITLE
NewURL(): return raw URL even if parsing error

### DIFF
--- a/pkg/models/url.go
+++ b/pkg/models/url.go
@@ -30,10 +30,14 @@ type URL struct {
 	once        sync.Once
 }
 
+// NewURL parses a raw URL string and returns a URL object.
+// If the URL is invalid, it returns a URL object with the raw string and an error.
 func NewURL(raw string) (URL, error) {
 	parsed, err := url.ParseRequestURI(raw)
 	if err != nil {
-		return URL{}, err
+		return URL{
+			Raw: raw,
+		}, err
 	}
 	return URL{
 		Raw:    raw,


### PR DESCRIPTION
For potential `finisher` debugging needs.

This does not affect any actual behavior. It just makes it more convenient to identify the bad url item that enters `globalHQ.finishCh` when debugging.