### PR TITLE
Handle default HQBatchSize in config

### DIFF
--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -138,6 +138,9 @@ func InitConfig() error {
 	once.Do(func() {
 		config = &Config{}
 
+		// Config defaults
+		viper.SetDefault("hq-batch-size", 100)
+
 		// Check if a config file is provided via flag
 		if configFile := viper.GetString("config-file"); configFile != "" {
 			viper.SetConfigFile(configFile)

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -1,0 +1,18 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestInitConfig_Defaults(t *testing.T) {
+	err := InitConfig()
+	if err != nil {
+		t.Fatalf("Cannot init config %v", err)
+	}
+	config := Get()
+
+	// HQBatchSize is set to 100 by default in InitConfig.
+	if config.HQBatchSize != 100 {
+		t.Fatalf("HQBatchSize default isn't set to 100 but %d", config.HQBatchSize)
+	}
+}

--- a/internal/pkg/source/hq/producer.go
+++ b/internal/pkg/source/hq/producer.go
@@ -71,7 +71,7 @@ func producerReceiver(ctx context.Context, wg *sync.WaitGroup, batchCh chan *pro
 		"component": "hq.producerReceiver",
 	})
 
-	batchSize := getProducerBatchSize()
+	batchSize := config.Get().HQBatchSize
 	maxWaitTime := 5 * time.Second
 
 	batch := &producerBatch{
@@ -198,13 +198,4 @@ func getMaxProducerSenders() int {
 		return 1
 	}
 	return workersCount / 10
-}
-
-// getProducerBatchSize returns the batch size based on configuration.
-func getProducerBatchSize() int {
-	batchSize := config.Get().HQBatchSize
-	if batchSize == 0 {
-		batchSize = 100 // Default batch size.
-	}
-	return batchSize
 }


### PR DESCRIPTION
In Go, when a struct field of type int is not explicitly initialized, its default value is 0. So, all config integers default to 0.
Then, in HQ producer we have a special function to set its default value to 100 if its 0.
We can simplify this using viper. We set the default HQBatchSize to 100 in `ConfigInit` and drop the redundant function.

We also add a small unit test to validate config init.