### PR TITLE
Simplify models.NewItem

### DIFF
--- a/internal/pkg/controler/pipeline.go
+++ b/internal/pkg/controler/pipeline.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/internetarchive/Zeno/internal/pkg/api"
 	"github.com/internetarchive/Zeno/internal/pkg/archiver"
 	"github.com/internetarchive/Zeno/internal/pkg/config"
@@ -141,7 +140,7 @@ func startPipeline() {
 				panic(err)
 			}
 
-			item := models.NewItem(uuid.New().String(), &parsedURL, "")
+			item := models.NewItem(&parsedURL, "")
 			item.SetSource(models.ItemSourceQueue)
 
 			err = reactor.ReceiveInsert(item)

--- a/internal/pkg/postprocessor/extractor/base_test.go
+++ b/internal/pkg/postprocessor/extractor/base_test.go
@@ -21,7 +21,7 @@ func newDocumentWithBaseTag(base string) *goquery.Document {
 func TestExtractBaseTag(t *testing.T) {
 	doc := newDocumentWithBaseTag("http://example.com/something/")
 
-	item := models.NewItem("test", &models.URL{
+	item := models.NewItem(&models.URL{
 		Raw: "https://example.com/something/page.html",
 	}, "")
 

--- a/internal/pkg/postprocessor/extractor/html_test.go
+++ b/internal/pkg/postprocessor/extractor/html_test.go
@@ -29,7 +29,7 @@ func setupItem(html string) *models.Item {
 	if err := archiver.ProcessBody(&newURL, false, false, 0, os.TempDir()); err != nil {
 		panic(err)
 	}
-	return models.NewItem("test", &newURL, "")
+	return models.NewItem(&newURL, "")
 }
 
 func TestHTMLOutlinks(t *testing.T) {

--- a/internal/pkg/postprocessor/extractor/resolve_test.go
+++ b/internal/pkg/postprocessor/extractor/resolve_test.go
@@ -114,7 +114,7 @@ func TestResolveURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			item := models.NewItem("test", &models.URL{
+			item := models.NewItemWithID("test", &models.URL{
 				Raw: tt.parentURL,
 			}, "")
 

--- a/internal/pkg/postprocessor/item.go
+++ b/internal/pkg/postprocessor/item.go
@@ -4,7 +4,6 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/google/uuid"
 	"github.com/internetarchive/Zeno/internal/pkg/config"
 	"github.com/internetarchive/Zeno/internal/pkg/log"
 	"github.com/internetarchive/Zeno/internal/pkg/postprocessor/domainscrawl"
@@ -46,7 +45,7 @@ func postprocessItem(item *models.Item) []*models.Item {
 			Hops:      item.GetURL().GetHops(),
 		}
 
-		newChild := models.NewItem(uuid.New().String(), newURL, "")
+		newChild := models.NewItem(newURL, "")
 		err := item.AddChild(newChild, models.ItemGotRedirected)
 		if err != nil {
 			panic(err)
@@ -62,7 +61,6 @@ func postprocessItem(item *models.Item) []*models.Item {
 	// case facebook.IsFacebookPostURL(item.GetURL()):
 	// 	err := item.AddChild(
 	// 		models.NewItem(
-	// 			uuid.New().String(),
 	// 			facebook.GenerateEmbedURL(item.GetURL()),
 	// 			item.GetURL().String(),
 	// 		), models.ItemGotChildren)
@@ -123,7 +121,7 @@ func postprocessItem(item *models.Item) []*models.Item {
 						}
 					}
 
-					newChild := models.NewItem(uuid.New().String(), assets[i], "")
+					newChild := models.NewItem(assets[i], "")
 					err = item.AddChild(newChild, models.ItemGotChildren)
 					if err != nil {
 						panic(err)
@@ -160,7 +158,7 @@ func postprocessItem(item *models.Item) []*models.Item {
 						continue
 					}
 
-					newOutlinkItem := models.NewItem(uuid.New().String(), newOutlinks[i], item.GetURL().String())
+					newOutlinkItem := models.NewItem(newOutlinks[i], item.GetURL().String())
 					outlinks = append(outlinks, newOutlinkItem)
 				}
 

--- a/internal/pkg/preprocessor/exclusion_test.go
+++ b/internal/pkg/preprocessor/exclusion_test.go
@@ -4,7 +4,6 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/internetarchive/Zeno/pkg/models"
 )
 
@@ -74,7 +73,7 @@ func TestMatchRegexExclusion(t *testing.T) {
 			if err != nil {
 				t.Errorf("URL parsing failed %v", err)
 			}
-			item := models.NewItem(uuid.New().String(), &parsedURL, "")
+			item := models.NewItem(&parsedURL, "")
 			got := matchRegexExclusion(regexps, item)
 			if got != tt.expectedMatched {
 				t.Errorf("Expected match: %v, got: %v", tt.expectedMatched, got)

--- a/internal/pkg/reactor/reactor_test.go
+++ b/internal/pkg/reactor/reactor_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/internetarchive/Zeno/internal/pkg/log"
 	"github.com/internetarchive/Zeno/pkg/models"
 )
@@ -98,8 +97,7 @@ func _testerFunc(tokens, consumers, seeds int, t testing.TB) {
 	// Create mock seeds
 	mockItems := []*models.Item{}
 	for i := 0; i < seeds; i++ {
-		uuid := uuid.New().String()
-		newItem := models.NewItem(uuid, &models.URL{Raw: fmt.Sprintf("http://example.com/%d", i)}, "")
+		newItem := models.NewItem(&models.URL{Raw: fmt.Sprintf("http://example.com/%d", i)}, "")
 		newItem.SetSource(models.ItemSourceInsert)
 		newItem.SetStatus(models.ItemFresh)
 		mockItems = append(mockItems, newItem)

--- a/internal/pkg/source/hq/consumer.go
+++ b/internal/pkg/source/hq/consumer.go
@@ -163,7 +163,7 @@ func consumerSender(ctx context.Context, wg *sync.WaitGroup, urlBuffer <-chan *g
 				discard = true
 			}
 			parsedURL.SetHops(pathToHops(URL.Path))
-			newItem := models.NewItem(URL.ID, &parsedURL, URL.Via)
+			newItem := models.NewItemWithID(URL.ID, &parsedURL, URL.Via)
 			newItem.SetStatus(models.ItemFresh)
 			newItem.SetSource(models.ItemSourceHQ)
 

--- a/internal/pkg/source/lq/consumer.go
+++ b/internal/pkg/source/lq/consumer.go
@@ -150,7 +150,7 @@ func consumerSender(ctx context.Context, wg *sync.WaitGroup, urlBuffer <-chan *s
 				discard = true
 			}
 			parsedURL.SetHops(int(URL.Hops))
-			newItem := models.NewItem(URL.ID, &parsedURL, URL.Via)
+			newItem := models.NewItemWithID(URL.ID, &parsedURL, URL.Via)
 			newItem.SetStatus(models.ItemFresh)
 			newItem.SetSource(models.ItemSourceQueue)
 

--- a/pkg/models/item.go
+++ b/pkg/models/item.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/google/uuid"
 )
 
 // Item represents a URL, it's children (e.g. discovered assets) and it's state in the pipeline
@@ -300,13 +301,27 @@ func (i *Item) SetBase(base *url.URL) { i.base = base }
 func (i *Item) SetError(err error) { i.err = err }
 
 // NewItem creates a new item with the given ID, URL and seedVia
-func NewItem(ID string, URL *URL, seedVia string) *Item {
+func NewItemWithID(ID string, URL *URL, seedVia string) *Item {
 	if ID == "" || URL == nil {
 		return nil
 	}
 
 	return &Item{
 		id:      ID,
+		url:     URL,
+		parent:  nil,
+		seedVia: seedVia,
+		status:  ItemFresh,
+	}
+}
+
+func NewItem(URL *URL, seedVia string) *Item {
+	if URL == nil {
+		return nil
+	}
+
+	return &Item{
+		id:      uuid.New().String(),
 		url:     URL,
 		parent:  nil,
 		seedVia: seedVia,

--- a/pkg/models/item_test.go
+++ b/pkg/models/item_test.go
@@ -1181,7 +1181,7 @@ func TestNewItem(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			item := NewItem(tt.id, tt.url, tt.via)
+			item := NewItemWithID(tt.id, tt.url, tt.via)
 			if tt.expected == nil && item != nil {
 				t.Errorf("expected nil, got: %v", item)
 			} else if item != nil {


### PR DESCRIPTION
Rename `models.NewItem` to `models.NewItemWithID`.
Create `models.NewItem(URL *URL, seedVia string)` which uses `uuid.New().String()` internally to define the `id`.
This way, the code becomes much cleaner.