### PR TITLE
Simplify item.GetStatus() logging

### DIFF
--- a/internal/pkg/archiver/archiver.go
+++ b/internal/pkg/archiver/archiver.go
@@ -170,7 +170,7 @@ func (a *archiver) worker(workerID string) {
 				}
 
 				if seed.GetStatus() != models.ItemPreProcessed && seed.GetStatus() != models.ItemGotRedirected && seed.GetStatus() != models.ItemGotChildren {
-					logger.Debug("skipping seed", "seed", seed.GetShortID(), "depth", seed.GetDepth(), "hops", seed.GetURL().GetHops(), "status", seed.GetStatus().String())
+					logger.Debug("skipping seed", "seed", seed.GetShortID(), "depth", seed.GetDepth(), "hops", seed.GetURL().GetHops(), "status", seed.GetStatus())
 				} else {
 					archive(workerID, seed)
 				}
@@ -205,7 +205,7 @@ func archive(workerID string, seed *models.Item) {
 
 	for i := range items {
 		if items[i].GetStatus() != models.ItemPreProcessed {
-			logger.Debug("skipping item", "seed_id", seed.GetShortID(), "item_id", items[i].GetShortID(), "status", items[i].GetStatus().String(), "depth", items[i].GetDepth())
+			logger.Debug("skipping item", "seed_id", seed.GetShortID(), "item_id", items[i].GetShortID(), "status", items[i].GetStatus(), "depth", items[i].GetDepth())
 			continue
 		}
 

--- a/internal/pkg/postprocessor/postprocessor.go
+++ b/internal/pkg/postprocessor/postprocessor.go
@@ -103,7 +103,7 @@ func (p *postprocessor) worker(workerID string) {
 				}
 
 				if seed.GetStatus() != models.ItemArchived && seed.GetStatus() != models.ItemGotRedirected && seed.GetStatus() != models.ItemGotChildren {
-					logger.Debug("skipping seed", "seed", seed.GetShortID(), "depth", seed.GetDepth(), "hops", seed.GetURL().GetHops(), "status", seed.GetStatus().String())
+					logger.Debug("skipping seed", "seed", seed.GetShortID(), "depth", seed.GetDepth(), "hops", seed.GetURL().GetHops(), "status", seed.GetStatus())
 				} else {
 					outlinks := postprocess(workerID, seed)
 					for i := range outlinks {

--- a/internal/pkg/preprocessor/preprocessor.go
+++ b/internal/pkg/preprocessor/preprocessor.go
@@ -157,7 +157,7 @@ func preprocess(workerID string, seed *models.Item) {
 		// Panic on any child that is not fresh
 		// This means that an incorrect item was inserted and/or that the finisher is not working correctly
 		if items[i].GetStatus() != models.ItemFresh {
-			dumper.PanicWithDump(fmt.Sprintf("non-fresh item %s received in preprocessor worker %s with status: %s", items[i].GetShortID(), workerID, items[i].GetStatus().String()), items[i])
+			dumper.PanicWithDump(fmt.Sprintf("non-fresh item %s received in preprocessor worker %s with status: %s", items[i].GetShortID(), workerID, items[i].GetStatus()), items[i])
 		}
 
 		// Normalize the URL


### PR DESCRIPTION
There is no need to use `item.GetStatus().String()` when logging because we have already defined `func (s ItemState) String()`. This is invoked automatically.