### PR TITLE
Extract more types of outlinks

### DIFF
--- a/internal/pkg/postprocessor/extractor/html.go
+++ b/internal/pkg/postprocessor/extractor/html.go
@@ -86,6 +86,14 @@ func HTMLOutlinks(item *models.Item) (outlinks []*models.URL, err error) {
 		})
 	}
 
+	if !slices.Contains(config.Get().DisableHTMLTag, "area") {
+		document.Find("area[href]").Each(func(index int, i *goquery.Selection) {
+			if href, exists := i.Attr("href"); exists && href != "" {
+				rawOutlinks = append(rawOutlinks, href)
+			}
+		})
+	}
+
 	for _, rawOutlink := range rawOutlinks {
 		resolvedURL, err := resolveURL(rawOutlink, item)
 		if err != nil {

--- a/internal/pkg/postprocessor/extractor/html.go
+++ b/internal/pkg/postprocessor/extractor/html.go
@@ -53,6 +53,7 @@ func HTMLOutlinks(item *models.Item) (outlinks []*models.URL, err error) {
 			"data-redirect-url",
 			"ping",
 			"onclick",
+			"ondblclick",
 			"router-link",
 			"to",
 		}
@@ -64,7 +65,7 @@ func HTMLOutlinks(item *models.Item) (outlinks []*models.URL, err error) {
 					continue
 				}
 
-				if key == "onclick" {
+				if key == "onclick" || key == "ondblclick" {
 					// Attempt to extract URL from JS like window.location = '...';
 					if matches := onclickRegex.FindStringSubmatch(val); len(matches) > 1 {
 						rawOutlinks = append(rawOutlinks, matches[1])

--- a/internal/pkg/postprocessor/extractor/html.go
+++ b/internal/pkg/postprocessor/extractor/html.go
@@ -261,12 +261,12 @@ func HTMLAssets(item *models.Item) (assets []*models.URL, err error) {
 			matches := urlRegex.FindAllStringSubmatch(i.Text(), -1)
 			for match := range matches {
 				matchReplacement := matches[match][1]
-				matchReplacement = strings.Replace(matchReplacement, "'", "", -1)
-				matchReplacement = strings.Replace(matchReplacement, "\"", "", -1)
+				matchReplacement = strings.ReplaceAll(matchReplacement, "'", "")
+				matchReplacement = strings.ReplaceAll(matchReplacement, "\"", "")
 
 				// If the URL already has http (or https), we don't need add anything to it.
 				if !strings.Contains(matchReplacement, "http") {
-					matchReplacement = strings.Replace(matchReplacement, "//", "http://", -1)
+					matchReplacement = strings.ReplaceAll(matchReplacement, "//", "http://")
 				}
 
 				if strings.HasPrefix(matchReplacement, "#wp-") {

--- a/internal/pkg/postprocessor/extractor/html_test.go
+++ b/internal/pkg/postprocessor/extractor/html_test.go
@@ -42,6 +42,7 @@ func TestHTMLOutlinks(t *testing.T) {
 			<p>test</p>
 			<a href="https://web.archive.org">wa</a>
 			<a onclick="window.location='http://foo.com'">click me</a>
+			<a ondblclick="window.location='https://bar.com'">double click me</a>
 			<iframe title="Internet Archive" src="https://web.archive.org"></iframe>
 		</body>
 	</html>`
@@ -51,8 +52,8 @@ func TestHTMLOutlinks(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error extracting HTML outlinks %s", err)
 	}
-	if len(outlinks) != 5 {
-		t.Errorf("We couldn't extract all HTML outlinks. Received %d, expected 5", len(outlinks))
+	if len(outlinks) != 6 {
+		t.Errorf("We couldn't extract all HTML outlinks. Received %d, expected 6", len(outlinks))
 	}
 }
 

--- a/internal/pkg/postprocessor/extractor/html_test.go
+++ b/internal/pkg/postprocessor/extractor/html_test.go
@@ -44,6 +44,10 @@ func TestHTMLOutlinks(t *testing.T) {
 			<a onclick="window.location='http://foo.com'">click me</a>
 			<a ondblclick="window.location='https://bar.com'">double click me</a>
 			<iframe title="Internet Archive" src="https://web.archive.org"></iframe>
+			<img src="world-map.jpg" usemap="#worldmap" alt="World Map">
+			<map name="worldmap">
+			  <area shape="rect" coords="34,44,270,350" href="https://example.com/usa" alt="USA">
+			</map>
 		</body>
 	</html>`
 	item := setupItem(html)
@@ -52,8 +56,8 @@ func TestHTMLOutlinks(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error extracting HTML outlinks %s", err)
 	}
-	if len(outlinks) != 6 {
-		t.Errorf("We couldn't extract all HTML outlinks. Received %d, expected 6", len(outlinks))
+	if len(outlinks) != 7 {
+		t.Errorf("We couldn't extract all HTML outlinks. Received %d, expected 7", len(outlinks))
 	}
 }
 


### PR DESCRIPTION
Extract outlinks from `ondblclick="<javascript>"` events and `<area href=".." />` html elements.

Add unit tests.

Inspiration came from Brozzler outlink extraction https://github.com/internetarchive/brozzler/blob/master/brozzler/js-templates/extract-outlinks.js