### PR TITLE
Simplify URL logging

### DIFF
--- a/internal/pkg/archiver/archiver.go
+++ b/internal/pkg/archiver/archiver.go
@@ -297,7 +297,7 @@ func archive(workerID string, seed *models.Item) {
 					}
 
 					if retry < config.Get().MaxRetry {
-						logger.Warn("retrying", "reason", retryReason, "seed_id", seed.GetShortID(), "item_id", item.GetShortID(), "depth", item.GetDepth(), "hops", item.GetURL().GetHops(), "retry", retry, "sleep_time", retrySleepTime, "status_code", resp.StatusCode, "url", req.URL.String())
+						logger.Warn("retrying", "reason", retryReason, "seed_id", seed.GetShortID(), "item_id", item.GetShortID(), "depth", item.GetDepth(), "hops", item.GetURL().GetHops(), "retry", retry, "sleep_time", retrySleepTime, "status_code", resp.StatusCode, "url", req.URL)
 
 						// Consume body, needed to avoid leaking RAM & storage
 						io.Copy(io.Discard, resp.Body)
@@ -306,7 +306,7 @@ func archive(workerID string, seed *models.Item) {
 						time.Sleep(retrySleepTime)
 						continue
 					} else {
-						logger.Error("retries exceeded", "reason", retryReason, "seed_id", seed.GetShortID(), "item_id", item.GetShortID(), "depth", item.GetDepth(), "hops", item.GetURL().GetHops(), "status_code", resp.StatusCode, "url", req.URL.String())
+						logger.Error("retries exceeded", "reason", retryReason, "seed_id", seed.GetShortID(), "item_id", item.GetShortID(), "depth", item.GetDepth(), "hops", item.GetURL().GetHops(), "status_code", resp.StatusCode, "url", req.URL)
 						item.SetStatus(models.ItemFailed)
 
 						// Consume body, needed to avoid leaking RAM & storage
@@ -349,7 +349,7 @@ func archive(workerID string, seed *models.Item) {
 				stats.MeanWaitOnFeedbackTimeAdd(time.Since(feedbackTime))
 			}
 
-			logger.Info("url archived", "url", item.GetURL().String(), "seed_id", seed.GetShortID(), "item_id", item.GetShortID(), "depth", item.GetDepth(), "hops", item.GetURL().GetHops(), "status", resp.StatusCode)
+			logger.Info("url archived", "url", item.GetURL(), "seed_id", seed.GetShortID(), "item_id", item.GetShortID(), "depth", item.GetDepth(), "hops", item.GetURL().GetHops(), "status", resp.StatusCode)
 
 			item.SetStatus(models.ItemArchived)
 		}(items[i])

--- a/internal/pkg/postprocessor/extractor/html.go
+++ b/internal/pkg/postprocessor/extractor/html.go
@@ -95,7 +95,7 @@ func HTMLOutlinks(item *models.Item) (outlinks []*models.URL, err error) {
 	for _, rawOutlink := range rawOutlinks {
 		resolvedURL, err := resolveURL(rawOutlink, item)
 		if err != nil {
-			logger.Debug("unable to resolve URL", "error", err, "url", item.GetURL().String(), "item", item.GetShortID())
+			logger.Debug("unable to resolve URL", "error", err, "url", item.GetURL(), "item", item.GetShortID())
 		} else if resolvedURL != "" {
 			outlinks = append(outlinks, &models.URL{
 				Raw: resolvedURL,
@@ -140,7 +140,7 @@ func HTMLAssets(item *models.Item) (assets []*models.URL, err error) {
 		if exists {
 			URLsFromJSON, _, err := GetURLsFromJSON(json.NewDecoder(strings.NewReader(dataItem)))
 			if err != nil {
-				logger.Debug("unable to extract URLs from JSON in data-item attribute", "err", err, "url", item.GetURL().String(), "item", item.GetShortID())
+				logger.Debug("unable to extract URLs from JSON in data-item attribute", "err", err, "url", item.GetURL(), "item", item.GetShortID())
 			} else {
 				rawAssets = append(rawAssets, URLsFromJSON...)
 			}
@@ -285,7 +285,7 @@ func HTMLAssets(item *models.Item) (assets []*models.URL, err error) {
 			// Apply regex on the script's HTML to extract potential assets
 			outerHTML, err := goquery.OuterHtml(i)
 			if err != nil {
-				logger.Debug("unable to extract outer HTML from script tag", "err", err, "url", item.GetURL().String(), "item", item.GetShortID())
+				logger.Debug("unable to extract outer HTML from script tag", "err", err, "url", item.GetURL(), "item", item.GetShortID())
 			} else {
 				var scriptLinks []string
 				if !config.Get().StrictRegex {
@@ -298,7 +298,7 @@ func HTMLAssets(item *models.Item) (assets []*models.URL, err error) {
 						// Escape URLs when unicode runes are present in the extracted URLs
 						scriptLink, err := strconv.Unquote(`"` + scriptLink + `"`)
 						if err != nil {
-							logger.Debug("unable to escape URL from JSON in script tag", "error", err, "url", item.GetURL().String(), "item", item.GetShortID())
+							logger.Debug("unable to escape URL from JSON in script tag", "error", err, "url", item.GetURL(), "item", item.GetShortID())
 							continue
 						}
 						rawAssets = append(rawAssets, scriptLink)
@@ -310,7 +310,7 @@ func HTMLAssets(item *models.Item) (assets []*models.URL, err error) {
 			if !strings.HasPrefix(i.Text(), "{") {
 				assetsFromScriptContent, err := extractFromScriptContent(i.Text())
 				if err != nil {
-					logger.Debug("unable to extract URLs from JSON in script tag", "error", err, "url", item.GetURL().String(), "item", item.GetShortID())
+					logger.Debug("unable to extract URLs from JSON in script tag", "error", err, "url", item.GetURL(), "item", item.GetShortID())
 				} else {
 					rawAssets = append(rawAssets, assetsFromScriptContent...)
 				}
@@ -390,7 +390,7 @@ func HTMLAssets(item *models.Item) (assets []*models.URL, err error) {
 			if item.GetBase() != nil {
 				baseURL = item.GetBase().String()
 			}
-			logger.Debug("unable to resolve URL", "error", err, "item_url", item.GetURL().String(), "base_url", baseURL, "target", rawAsset, "item", item.GetShortID())
+			logger.Debug("unable to resolve URL", "error", err, "item_url", item.GetURL(), "base_url", baseURL, "target", rawAsset, "item", item.GetShortID())
 		} else if resolvedURL != "" {
 			assets = append(assets, &models.URL{
 				Raw: resolvedURL,

--- a/internal/pkg/postprocessor/outlinks.go
+++ b/internal/pkg/postprocessor/outlinks.go
@@ -28,7 +28,7 @@ func extractOutlinks(item *models.Item) (outlinks []*models.URL, err error) {
 	)
 
 	if item.GetURL().GetBody() == nil {
-		logger.Error("no body to extract outlinks from", "url", item.GetURL().String(), "item", item.GetShortID())
+		logger.Error("no body to extract outlinks from", "url", item.GetURL(), "item", item.GetShortID())
 		return
 	}
 
@@ -37,19 +37,19 @@ func extractOutlinks(item *models.Item) (outlinks []*models.URL, err error) {
 	case truthsocial.IsAccountURL(item.GetURL()):
 		outlinks, err = truthsocial.GenerateAccountLookupURL(item.GetURL())
 		if err != nil {
-			logger.Error("unable to extract outlinks", "extractor", "truthsocial.GenerateAccountLookupURL", "err", err.Error(), "item", item.GetShortID(), "url", item.GetURL().String())
+			logger.Error("unable to extract outlinks", "extractor", "truthsocial.GenerateAccountLookupURL", "err", err.Error(), "item", item.GetShortID(), "url", item.GetURL())
 			return outlinks, err
 		}
 	case truthsocial.IsAccountLookupURL(item.GetURL()):
 		outlinks, err = truthsocial.GenerateOutlinksURLsFromLookup(item.GetURL())
 		if err != nil {
-			logger.Error("unable to extract outlinks", "extractor", "truthsocial.GenerateOutlinksURLsFromLookup", "err", err.Error(), "item", item.GetShortID(), "url", item.GetURL().String())
+			logger.Error("unable to extract outlinks", "extractor", "truthsocial.GenerateOutlinksURLsFromLookup", "err", err.Error(), "item", item.GetShortID(), "url", item.GetURL())
 			return outlinks, err
 		}
 	case extractor.IsObjectStorage(item.GetURL()):
 		outlinks, err = extractor.ObjectStorage(item.GetURL())
 		if err != nil {
-			logger.Error("unable to extract outlinks from ObjectStorage", "extractor", "ObjectStorage", "err", err.Error(), "item", item.GetShortID(), "url", item.GetURL().String())
+			logger.Error("unable to extract outlinks from ObjectStorage", "extractor", "ObjectStorage", "err", err.Error(), "item", item.GetShortID(), "url", item.GetURL())
 			return outlinks, err
 		}
 	case extractor.IsSitemapXML(item.GetURL()):
@@ -57,7 +57,7 @@ func extractOutlinks(item *models.Item) (outlinks []*models.URL, err error) {
 
 		assets, outlinks, err = extractor.XML(item.GetURL())
 		if err != nil {
-			logger.Error("unable to extract outlinks", "extractor", "XML", "err", err.Error(), "item", item.GetShortID(), "url", item.GetURL().String())
+			logger.Error("unable to extract outlinks", "extractor", "XML", "err", err.Error(), "item", item.GetShortID(), "url", item.GetURL())
 			return outlinks, err
 		}
 
@@ -67,23 +67,23 @@ func extractOutlinks(item *models.Item) (outlinks []*models.URL, err error) {
 	case extractor.IsHTML(item.GetURL()):
 		outlinks, err = extractor.HTMLOutlinks(item)
 		if err != nil {
-			logger.Error("unable to extract outlinks", "extractor", "HTMLOutlinks", "err", err.Error(), "item", item.GetShortID(), "url", item.GetURL().String())
+			logger.Error("unable to extract outlinks", "extractor", "HTMLOutlinks", "err", err.Error(), "item", item.GetShortID(), "url", item.GetURL())
 			return outlinks, err
 		}
 	case extractor.IsPDF(item.GetURL()):
 		outlinks, err = extractor.PDF(item.GetURL())
 		if err != nil {
-			logger.Error("unable to extract outlinks", "extractor", "PDF", "err", err.Error(), "item", item.GetShortID(), "url", item.GetURL().String())
+			logger.Error("unable to extract outlinks", "extractor", "PDF", "err", err.Error(), "item", item.GetShortID(), "url", item.GetURL())
 			return outlinks, err
 		}
 	case reddit.IsPostAPI(item.GetURL()):
 		outlinks, err = reddit.ExtractAPIPostPermalinks(item)
 		if err != nil {
-			logger.Error("unable to extract outlinks", "extractor", "reddit.ExtractAPIPostPermalinks", "err", err.Error(), "item", item.GetShortID(), "url", item.GetURL().String())
+			logger.Error("unable to extract outlinks", "extractor", "reddit.ExtractAPIPostPermalinks", "err", err.Error(), "item", item.GetShortID(), "url", item.GetURL())
 			return outlinks, err
 		}
 	default:
-		logger.Debug("no extractor used for page", "content-type", contentType, "item", item.GetShortID(), "url", item.GetURL().String())
+		logger.Debug("no extractor used for page", "content-type", contentType, "item", item.GetShortID(), "url", item.GetURL())
 		return outlinks, nil
 	}
 

--- a/internal/pkg/preprocessor/preprocessor.go
+++ b/internal/pkg/preprocessor/preprocessor.go
@@ -185,7 +185,7 @@ func preprocess(workerID string, seed *models.Item) {
 				logger.Debug("URL excluded (does not match include filters)",
 					"item_id", items[i].GetShortID(),
 					"seed_id", seed.GetShortID(),
-					"url", items[i].GetURL().String())
+					"url", items[i].GetURL())
 
 				if items[i].IsChild() || items[i].IsRedirection() {
 					items[i].GetParent().RemoveChild(items[i])
@@ -205,7 +205,7 @@ func preprocess(workerID string, seed *models.Item) {
 			logger.Debug("URL excluded (matches exclusion filters)",
 				"item_id", items[i].GetShortID(),
 				"seed_id", seed.GetShortID(),
-				"url", items[i].GetURL().String())
+				"url", items[i].GetURL())
 
 			if items[i].IsChild() || items[i].IsRedirection() {
 				items[i].GetParent().RemoveChild(items[i])
@@ -276,7 +276,7 @@ func preprocess(workerID string, seed *models.Item) {
 	for i := range items {
 		req, err := http.NewRequest(http.MethodGet, items[i].GetURL().String(), nil)
 		if err != nil {
-			logger.Error("unable to create request for URL", "item_id", items[i].GetShortID(), "seed_id", seed.GetShortID(), "url", items[i].GetURL().String(), "err", err.Error())
+			logger.Error("unable to create request for URL", "item_id", items[i].GetShortID(), "seed_id", seed.GetShortID(), "url", items[i].GetURL(), "err", err.Error())
 			items[i].SetStatus(models.ItemFailed)
 			continue
 		}


### PR DESCRIPTION
`pkg.model.URL` has `String()` method which means that it is invoked automatically when you log it. There is no need to call `.String()`.

`net/url` also supports the same.