### PR TITLE
Move closeBody(seed *model.Item) to Item.Close()

### DIFF
--- a/internal/pkg/postprocessor/item.go
+++ b/internal/pkg/postprocessor/item.go
@@ -12,7 +12,7 @@ import (
 )
 
 func postprocessItem(item *models.Item) []*models.Item {
-	defer closeBody(item)
+	defer item.Close()
 
 	logger := log.NewFieldedLogger(&log.Fields{
 		"component": "postprocessor.postprocess.postprocessItem",

--- a/internal/pkg/postprocessor/postprocessor.go
+++ b/internal/pkg/postprocessor/postprocessor.go
@@ -154,17 +154,6 @@ func postprocess(workerID string, seed *models.Item) []*models.Item {
 
 func closeBodies(seed *models.Item) {
 	seed.Traverse(func(seed *models.Item) {
-		closeBody(seed)
+		seed.Close()
 	})
-}
-
-func closeBody(seed *models.Item) {
-	if seed.GetURL().GetBody() != nil {
-		err := seed.GetURL().GetBody().Close()
-		if err != nil {
-			panic(fmt.Sprintf("unable to close body, err: %s, seed id: %s", err.Error(), seed.GetShortID()))
-		}
-
-		seed.GetURL().SetBody(nil)
-	}
 }

--- a/pkg/models/item.go
+++ b/pkg/models/item.go
@@ -423,6 +423,16 @@ func (i *Item) CompleteAndCheck() bool {
 	return !i.HasWork()
 }
 
+func (i *Item) Close() {
+    if i.url.GetBody() != nil {
+        err := i.url.GetBody().Close()
+        if err != nil {
+            panic(fmt.Sprintf("unable to close body, err: %s, seed id: %s", err.Error(), i.GetShortID()))
+        }
+        i.url.SetBody(nil)
+    }
+}
+
 // Errors definition
 var (
 	// ErrNotASeed is returned when the item is not a seed


### PR DESCRIPTION
`closeBody` is a function about the internal state of the `Item`. It makes sense to put it in `pkg.models.item` and use it as `Item.Close()`. Its better to have all the `Item` related methods in one place in `pkg.models.Item` instead of having them spread in preprocessor / postprocessor code.