### PR TITLE
removed unused config parameters

### DIFF
--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -78,7 +78,6 @@ type Config struct {
 	CertValidation           bool     `mapstructure:"cert-validation"`
 	DisableAssetsCapture     bool     `mapstructure:"disable-assets-capture"`
 	UseHQ                    bool     // Special field to check if HQ is enabled depending on the command called
-	HQRateLimitingSendBack   bool     `mapstructure:"hq-rate-limiting-send-back"`
 
 	// Network
 	Proxy         string `mapstructure:"proxy"`


### PR DESCRIPTION
I searched through the config struct found in ```pkg/config/config.go``` to see if any parameters were defined in the struct but *not* used anywhere else in the codebase, I could only find one parameter that was not used anywhere else.

I'm new to this project (hello) as well as go, so I will not take offense if this PR is not good at all. Just trying to help! :)

resolves #213 

Thanks