### PR TITLE
Extracting URLs from CSS `@import` rule

### DIFF
--- a/internal/pkg/postprocessor/extractor/css.go
+++ b/internal/pkg/postprocessor/extractor/css.go
@@ -330,8 +330,8 @@ func IsCSS(URL *models.URL) bool {
 	return isContentType(URL.GetResponse().Header.Get("Content-Type"), "text/css")
 }
 
-// ExtracFromStringCSS extracts URLs from a CSS content string.
-func ExtracFromStringCSS(cssBody string, inline bool) (links []string, atImportLinks []string, err error) {
+// ExtractFromStringCSS extracts URLs from a CSS content string.
+func ExtractFromStringCSS(cssBody string, inline bool) (links []string, atImportLinks []string, err error) {
 	return parseCSS(bytes.NewBufferString(cssBody), inline)
 }
 

--- a/internal/pkg/postprocessor/extractor/css_test.go
+++ b/internal/pkg/postprocessor/extractor/css_test.go
@@ -165,7 +165,7 @@ func TestCSSURL(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			links, atImportLinks, err := ExtracFromStringCSS(tt.CSS, tt.inline)
+			links, atImportLinks, err := ExtractFromStringCSS(tt.CSS, tt.inline)
 			if (err != nil) != tt.err {
 				t.Errorf("Expected error %v, got %v", tt.err, err)
 			}

--- a/internal/pkg/postprocessor/extractor/css_test.go
+++ b/internal/pkg/postprocessor/extractor/css_test.go
@@ -4,10 +4,11 @@ import "testing"
 
 func TestCSSURL(t *testing.T) {
 	tests := []struct {
-		name          string
-		CSS           string
-		expectedLinks []string
-		inline        bool
+		name                  string
+		CSS                   string
+		expectedLinks         []string
+		expectedAtImportLinks []string
+		inline                bool
 	}{
 		{
 			name:          "Valid String URL",
@@ -106,17 +107,78 @@ func TestCSSURL(t *testing.T) {
 			expectedLinks: []string{"https://example.com/style.css"},
 			inline:        true,
 		},
+		{
+			name: "At-Import Rules",
+			CSS: `
+				/* comment A */
+				@charset "UTF-8";
+				/* comment B */
+
+
+				@layer any;
+				@layer default, theme, components;
+				@import "1.css";
+				@import url("2.css");
+				@import url("3.css") print;
+				@import url("4.css") print, screen;
+				@import "5.css" screen;
+				/* comment C */
+				@import url("6.css") screen and (orientation: landscape);
+				@import url("7.css") supports(display: grid) screen and (max-width: 400px);
+				@import url("8.css") supports((not (display: grid)) and (display: flex))
+				screen and (max-width: 400px);
+				@import url("9.css")
+				supports((selector(h2 > p)) and (font-tech(color-COLRv1)));
+
+				/* and must not have any other valid at-rules or style rules between it and previous @import rules */
+				@layer IBreakAfterImports;
+				@import url("invalid.css"); /* this is a invalid @import rule */
+
+				div {
+					background-image: url("image.png");
+				}`,
+			expectedLinks: []string{"image.png"},
+			// no "invalid.css" because it's not a valid @import rule
+			expectedAtImportLinks: []string{"1.css", "2.css", "3.css", "4.css", "5.css", "6.css", "7.css", "8.css", "9.css"},
+			inline:                false,
+		},
+		{
+			name: "At-Import Rules after layer block",
+			CSS: `
+				@layer reset {
+					audio[controls] {
+						display: abc;
+					}
+				}
+				@import "1.css";
+
+				a {
+					background-image: url("image.png");
+				}`,
+			expectedLinks:         []string{"image.png"},
+			expectedAtImportLinks: []string{},
+			inline:                false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			links := CSS(tt.CSS, tt.inline)
+			links, atImportLinks := CSS(tt.CSS, tt.inline)
 			if len(links) != len(tt.expectedLinks) {
 				t.Errorf("Expected %d links, got %d", len(tt.expectedLinks), len(links))
+				return
+			}
+			if len(atImportLinks) != len(tt.expectedAtImportLinks) {
+				t.Errorf("Expected %d at-import links, got %d", len(tt.expectedAtImportLinks), len(atImportLinks))
 				return
 			}
 			for i, link := range links {
 				if link != tt.expectedLinks[i] {
 					t.Errorf("Expected link %s, got %s", tt.expectedLinks[i], link)
+				}
+			}
+			for i, atImportLink := range atImportLinks {
+				if atImportLink != tt.expectedAtImportLinks[i] {
+					t.Errorf("Expected at-import link %s, got %s", tt.expectedAtImportLinks[i], atImportLink)
 				}
 			}
 		})

--- a/internal/pkg/postprocessor/extractor/css_test.go
+++ b/internal/pkg/postprocessor/extractor/css_test.go
@@ -9,6 +9,7 @@ func TestCSSURL(t *testing.T) {
 		expectedLinks         []string
 		expectedAtImportLinks []string
 		inline                bool
+		err                   bool
 	}{
 		{
 			name:          "Valid String URL",
@@ -100,12 +101,14 @@ func TestCSSURL(t *testing.T) {
 			CSS:           `url("https://example.com/style.css");`,
 			expectedLinks: []string{},
 			inline:        false,
+			err:           true, // got unexpected token in declaration
 		},
 		{
 			name:          "bare declaration URL inline CSS",
 			CSS:           `url("https://example.com/style.css");`,
 			expectedLinks: []string{"https://example.com/style.css"},
 			inline:        true,
+			err:           true, // got unexpected token in declaration
 		},
 		{
 			name: "At-Import Rules",
@@ -162,7 +165,10 @@ func TestCSSURL(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			links, atImportLinks := CSS(tt.CSS, tt.inline)
+			links, atImportLinks, err := ExtracFromStringCSS(tt.CSS, tt.inline)
+			if (err != nil) != tt.err {
+				t.Errorf("Expected error %v, got %v", tt.err, err)
+			}
 			if len(links) != len(tt.expectedLinks) {
 				t.Errorf("Expected %d links, got %d", len(tt.expectedLinks), len(links))
 				return

--- a/internal/pkg/postprocessor/extractor/html.go
+++ b/internal/pkg/postprocessor/extractor/html.go
@@ -148,7 +148,8 @@ func HTMLAssets(item *models.Item) (assets []*models.URL, err error) {
 
 		style, exists := i.Attr("style")
 		if exists {
-			rawAssets = append(rawAssets, CSS(style, true)...)
+			links, _ := CSS(style, true)
+			rawAssets = append(rawAssets, links...)
 		}
 
 		dataPreview, exists := i.Attr("data-preview")
@@ -246,7 +247,7 @@ func HTMLAssets(item *models.Item) (assets []*models.URL, err error) {
 
 	if !slices.Contains(config.Get().DisableHTMLTag, "style") {
 		document.Find("style").Each(func(index int, i *goquery.Selection) {
-			links := CSS(i.Text(), false)
+			links, _ := CSS(i.Text(), false)
 			for _, link := range links {
 				// If the URL already has http (or https), we don't need add anything to it.
 				if !strings.Contains(link, "http") {

--- a/internal/pkg/postprocessor/extractor/html.go
+++ b/internal/pkg/postprocessor/extractor/html.go
@@ -148,7 +148,10 @@ func HTMLAssets(item *models.Item) (assets []*models.URL, err error) {
 
 		style, exists := i.Attr("style")
 		if exists {
-			links, _ := CSS(style, true)
+			links, _, err := ExtracFromStringCSS(style, true)
+			if err != nil {
+				cssLogger.Warn("error parsing inline attribute style CSS", "err", err, "url", item.GetURL(), "item", item.GetShortID(), "links", len(links))
+			}
 			rawAssets = append(rawAssets, links...)
 		}
 
@@ -247,7 +250,10 @@ func HTMLAssets(item *models.Item) (assets []*models.URL, err error) {
 
 	if !slices.Contains(config.Get().DisableHTMLTag, "style") {
 		document.Find("style").Each(func(index int, i *goquery.Selection) {
-			links, _ := CSS(i.Text(), false)
+			links, atImportLinks, err := ExtracFromStringCSS(i.Text(), false)
+			if err != nil {
+				cssLogger.Warn("error parsing HTML style block CSS", "err", err, "url", item.GetURL(), "item", item.GetShortID(), "links", len(links), "at_import_links", len(atImportLinks))
+			}
 			for _, link := range links {
 				// If the URL already has http (or https), we don't need add anything to it.
 				if !strings.Contains(link, "http") {

--- a/internal/pkg/postprocessor/extractor/html.go
+++ b/internal/pkg/postprocessor/extractor/html.go
@@ -148,7 +148,7 @@ func HTMLAssets(item *models.Item) (assets []*models.URL, err error) {
 
 		style, exists := i.Attr("style")
 		if exists {
-			links, _, err := ExtracFromStringCSS(style, true)
+			links, _, err := ExtractFromStringCSS(style, true)
 			if err != nil {
 				cssLogger.Warn("error parsing inline attribute style CSS", "err", err, "url", item.GetURL(), "item", item.GetShortID(), "links", len(links))
 			}
@@ -250,7 +250,7 @@ func HTMLAssets(item *models.Item) (assets []*models.URL, err error) {
 
 	if !slices.Contains(config.Get().DisableHTMLTag, "style") {
 		document.Find("style").Each(func(index int, i *goquery.Selection) {
-			links, atImportLinks, err := ExtracFromStringCSS(i.Text(), false)
+			links, atImportLinks, err := ExtractFromStringCSS(i.Text(), false)
 			if err != nil {
 				cssLogger.Warn("error parsing HTML style block CSS", "err", err, "url", item.GetURL(), "item", item.GetShortID(), "links", len(links), "at_import_links", len(atImportLinks))
 			}


### PR DESCRIPTION
#323
close: #296 

This PR adds the ability to extract `@import` urls at the css extractor level.

---

Crawling and archiving these `@import` urls will be implemented in the next PR.