### PR TITLE
Make config more unit-test friendly

### DIFF
--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -127,7 +127,7 @@ type Config struct {
 }
 
 var (
-	config *Config
+	AppConfig *Config
 	once   sync.Once
 )
 
@@ -137,7 +137,7 @@ var (
 func InitConfig() error {
 	var err error
 	once.Do(func() {
-		config = &Config{}
+		AppConfig = &Config{}
 
 		// Check if a config file is provided via flag
 		if configFile := viper.GetString("config-file"); configFile != "" {
@@ -187,7 +187,7 @@ func InitConfig() error {
 		handleFlagsAliases()
 
 		// Unmarshal the config into the Config struct
-		err = viper.Unmarshal(config)
+		err = viper.Unmarshal(AppConfig)
 	})
 	return err
 }
@@ -203,14 +203,14 @@ func BindFlags(flagSet *pflag.FlagSet) {
 
 // Get returns the config struct
 func Get() *Config {
-	return config
+	return AppConfig
 }
 
 func GenerateCrawlConfig() error {
 	// If the job name isn't specified, we generate a random name
-	if config.Job == "" {
-		if config.HQProject != "" {
-			config.Job = config.HQProject
+	if AppConfig.Job == "" {
+		if AppConfig.HQProject != "" {
+			AppConfig.Job = AppConfig.HQProject
 		} else {
 			UUID, err := uuid.NewUUID()
 			if err != nil {
@@ -218,28 +218,28 @@ func GenerateCrawlConfig() error {
 				return err
 			}
 
-			config.Job = UUID.String()
+			AppConfig.Job = UUID.String()
 		}
 	}
 
 	// Prometheus syntax does not play nice with hyphens
-	config.JobPrometheus = strings.ReplaceAll(config.Job, "-", "")
-	config.JobPath = path.Join("jobs", config.Job)
-	config.UseSeencheck = !config.DisableSeencheck
+	AppConfig.JobPrometheus = strings.ReplaceAll(AppConfig.Job, "-", "")
+	AppConfig.JobPath = path.Join("jobs", AppConfig.Job)
+	AppConfig.UseSeencheck = !AppConfig.DisableSeencheck
 
 	// Defaults --max-crawl-time-limit to 10% more than --crawl-time-limit
-	if config.CrawlMaxTimeLimit == 0 && config.CrawlTimeLimit != 0 {
-		config.CrawlMaxTimeLimit = config.CrawlTimeLimit + (config.CrawlTimeLimit / 10)
+	if AppConfig.CrawlMaxTimeLimit == 0 && AppConfig.CrawlTimeLimit != 0 {
+		AppConfig.CrawlMaxTimeLimit = AppConfig.CrawlTimeLimit + (AppConfig.CrawlTimeLimit / 10)
 	}
 
 	// We exclude some hosts by default
-	config.ExcludeHosts = utils.DedupeStrings(append(config.ExcludeHosts, "archive.org", "archive-it.org"))
+	AppConfig.ExcludeHosts = utils.DedupeStrings(append(AppConfig.ExcludeHosts, "archive.org", "archive-it.org"))
 
-	if config.WARCTempDir == "" {
-		config.WARCTempDir = path.Join(config.JobPath, "temp")
+	if AppConfig.WARCTempDir == "" {
+		AppConfig.WARCTempDir = path.Join(AppConfig.JobPath, "temp")
 	}
 
-	if config.UserAgent == "" {
+	if AppConfig.UserAgent == "" {
 		version := utils.GetVersion()
 
 		// If Version is a commit hash, we only take the first 7 characters
@@ -247,25 +247,25 @@ func GenerateCrawlConfig() error {
 			version.Version = version.Version[:7]
 		}
 
-		config.UserAgent = "Mozilla/5.0 (compatible; archive.org_bot +http://archive.org/details/archive.org_bot) Zeno/" + version.Version + " warc/" + version.WarcVersion
-		slog.Info("User-Agent set to", "user-agent", config.UserAgent)
+		AppConfig.UserAgent = "Mozilla/5.0 (compatible; archive.org_bot +http://archive.org/details/archive.org_bot) Zeno/" + version.Version + " warc/" + version.WarcVersion
+		slog.Info("User-Agent set to", "user-agent", AppConfig.UserAgent)
 	}
 
-	if config.RandomLocalIP {
+	if AppConfig.RandomLocalIP {
 		slog.Warn("Random local IP is enabled")
 	}
 
-	if config.DisableIPv4 && config.DisableIPv6 {
+	if AppConfig.DisableIPv4 && AppConfig.DisableIPv6 {
 		slog.Error("Both IPv4 and IPv6 are disabled, at least one of them must be enabled.")
 		os.Exit(1)
-	} else if config.DisableIPv4 {
+	} else if AppConfig.DisableIPv4 {
 		slog.Info("IPv4 is disabled")
-	} else if config.DisableIPv6 {
+	} else if AppConfig.DisableIPv6 {
 		slog.Info("IPv6 is disabled")
 	}
 
-	if len(config.ExclusionFile) > 0 {
-		for _, file := range config.ExclusionFile {
+	if len(AppConfig.ExclusionFile) > 0 {
+		for _, file := range AppConfig.ExclusionFile {
 			var (
 				regexes []string
 				err     error
@@ -288,13 +288,13 @@ func GenerateCrawlConfig() error {
 			slog.Info("Compiling exclusion regexes", "regexes", len(regexes))
 			compiledRegexes := compileRegexes(regexes)
 
-			config.ExclusionRegexes = append(config.ExclusionRegexes, compiledRegexes...)
+			AppConfig.ExclusionRegexes = append(AppConfig.ExclusionRegexes, compiledRegexes...)
 		}
 	}
 
-	if len(config.DomainsCrawl) > 0 {
-		slog.Info("Domains crawl enabled", "domains/regex", config.DomainsCrawl)
-		err := domainscrawl.AddElements(config.DomainsCrawl)
+	if len(AppConfig.DomainsCrawl) > 0 {
+		slog.Info("Domains crawl enabled", "domains/regex", AppConfig.DomainsCrawl)
+		err := domainscrawl.AddElements(AppConfig.DomainsCrawl)
 		if err != nil {
 			panic(err)
 		}
@@ -340,7 +340,7 @@ func readRemoteExclusionFile(URL string) (regexes []string, err error) {
 		return regexes, err
 	}
 
-	req.Header.Set("User-Agent", config.UserAgent)
+	req.Header.Set("User-Agent", AppConfig.UserAgent)
 
 	resp, err := httpClient.Do(req)
 	if err != nil {

--- a/internal/pkg/postprocessor/extractor/html.go
+++ b/internal/pkg/postprocessor/extractor/html.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/PuerkitoBio/goquery"
-	"github.com/internetarchive/Zeno/internal/pkg/config"
+	. "github.com/internetarchive/Zeno/internal/pkg/config"
 	"github.com/internetarchive/Zeno/internal/pkg/log"
 	"github.com/internetarchive/Zeno/internal/pkg/utils"
 	"github.com/internetarchive/Zeno/pkg/models"
@@ -42,7 +42,7 @@ func HTMLOutlinks(item *models.Item) (outlinks []*models.URL, err error) {
 
 	// Match <a> tags with href, data-href, data-src, data-srcset, data-lazy-src, data-srcset, src, srcset
 	// Extract potential URLs from <a> tags using common attributes
-	if !slices.Contains(config.Get().DisableHTMLTag, "a") {
+	if !slices.Contains(AppConfig.DisableHTMLTag, "a") {
 		attrs := []string{
 			"href",
 			"data-href",
@@ -76,7 +76,7 @@ func HTMLOutlinks(item *models.Item) (outlinks []*models.URL, err error) {
 		})
 	}
 
-	if !slices.Contains(config.Get().DisableHTMLTag, "iframe") {
+	if !slices.Contains(AppConfig.DisableHTMLTag, "iframe") {
 		document.Find("iframe[src]").Each(func(index int, i *goquery.Selection) {
 			if src, exists := i.Attr("src"); exists && src != "" {
 				rawOutlinks = append(rawOutlinks, src)
@@ -84,7 +84,7 @@ func HTMLOutlinks(item *models.Item) (outlinks []*models.URL, err error) {
 		})
 	}
 
-	if !slices.Contains(config.Get().DisableHTMLTag, "area") {
+	if !slices.Contains(AppConfig.DisableHTMLTag, "area") {
 		document.Find("area[href]").Each(func(index int, i *goquery.Selection) {
 			if href, exists := i.Attr("href"); exists && href != "" {
 				rawOutlinks = append(rawOutlinks, href)
@@ -164,7 +164,7 @@ func HTMLAssets(item *models.Item) (assets []*models.URL, err error) {
 	})
 
 	// Try to find assets in <a> tags.. this is a bit funky
-	if !slices.Contains(config.Get().DisableHTMLTag, "a") {
+	if !slices.Contains(AppConfig.DisableHTMLTag, "a") {
 		var validAssetPath = []string{
 			"static/",
 			"assets/",
@@ -198,7 +198,7 @@ func HTMLAssets(item *models.Item) (assets []*models.URL, err error) {
 	}
 
 	// Extract assets on the page (images, scripts, videos..)
-	if !slices.Contains(config.Get().DisableHTMLTag, "img") {
+	if !slices.Contains(AppConfig.DisableHTMLTag, "img") {
 		document.Find("img").Each(func(index int, i *goquery.Selection) {
 			link, exists := i.Attr("src")
 			if exists {
@@ -234,10 +234,10 @@ func HTMLAssets(item *models.Item) (assets []*models.URL, err error) {
 	}
 
 	var targetElements = []string{}
-	if !slices.Contains(config.Get().DisableHTMLTag, "video") {
+	if !slices.Contains(AppConfig.DisableHTMLTag, "video") {
 		targetElements = append(targetElements, "video[src]")
 	}
-	if !slices.Contains(config.Get().DisableHTMLTag, "audio") {
+	if !slices.Contains(AppConfig.DisableHTMLTag, "audio") {
 		targetElements = append(targetElements, "audio[src]")
 	}
 	if len(targetElements) > 0 {
@@ -248,7 +248,7 @@ func HTMLAssets(item *models.Item) (assets []*models.URL, err error) {
 		})
 	}
 
-	if !slices.Contains(config.Get().DisableHTMLTag, "style") {
+	if !slices.Contains(AppConfig.DisableHTMLTag, "style") {
 		document.Find("style").Each(func(index int, i *goquery.Selection) {
 			links, atImportLinks, err := ExtractFromStringCSS(i.Text(), false)
 			if err != nil {
@@ -269,7 +269,7 @@ func HTMLAssets(item *models.Item) (assets []*models.URL, err error) {
 		})
 	}
 
-	if !slices.Contains(config.Get().DisableHTMLTag, "script") {
+	if !slices.Contains(AppConfig.DisableHTMLTag, "script") {
 		document.Find("script").Each(func(index int, i *goquery.Selection) {
 			link, exists := i.Attr("src")
 			if exists {
@@ -295,7 +295,7 @@ func HTMLAssets(item *models.Item) (assets []*models.URL, err error) {
 				logger.Debug("unable to extract outer HTML from script tag", "err", err, "url", item.GetURL(), "item", item.GetShortID())
 			} else {
 				var scriptLinks []string
-				if !config.Get().StrictRegex {
+				if !AppConfig.StrictRegex {
 					scriptLinks = utils.DedupeStrings(LinkRegex.FindAllString(outerHTML, -1))
 				} else {
 					scriptLinks = utils.DedupeStrings(LinkRegexStrict.FindAllString(outerHTML, -1))
@@ -325,9 +325,9 @@ func HTMLAssets(item *models.Item) (assets []*models.URL, err error) {
 		})
 	}
 
-	if !slices.Contains(config.Get().DisableHTMLTag, "link") {
+	if !slices.Contains(AppConfig.DisableHTMLTag, "link") {
 		document.Find("link[href]").Each(func(index int, i *goquery.Selection) {
-			if !config.Get().CaptureAlternatePages {
+			if !AppConfig.CaptureAlternatePages {
 				if i.AttrOr("rel", "") == "alternate" {
 					return
 				}
@@ -339,7 +339,7 @@ func HTMLAssets(item *models.Item) (assets []*models.URL, err error) {
 		})
 	}
 
-	if !slices.Contains(config.Get().DisableHTMLTag, "meta") {
+	if !slices.Contains(AppConfig.DisableHTMLTag, "meta") {
 		document.Find("meta[href], meta[content]").Each(func(index int, i *goquery.Selection) {
 			link, exists := i.Attr("href")
 			if exists {
@@ -355,7 +355,7 @@ func HTMLAssets(item *models.Item) (assets []*models.URL, err error) {
 		})
 	}
 
-	if !slices.Contains(config.Get().DisableHTMLTag, "source") {
+	if !slices.Contains(AppConfig.DisableHTMLTag, "source") {
 		document.Find("source").Each(func(index int, i *goquery.Selection) {
 			link, exists := i.Attr("src")
 			if exists {
@@ -381,7 +381,7 @@ func HTMLAssets(item *models.Item) (assets []*models.URL, err error) {
 	}
 
 	// Extract WACZ files from replayweb embeds (docs: https://replayweb.page/docs/embedding/ )
-	if !slices.Contains(config.Get().DisableHTMLTag, "replay-web-page") {
+	if !slices.Contains(AppConfig.DisableHTMLTag, "replay-web-page") {
 		document.Find("replay-web-page[source]").Each(func(index int, i *goquery.Selection) {
 			source, exists := i.Attr("source")
 			if exists {


### PR DESCRIPTION
The Config struct is stored in a local var and returned via `config.Get()`. If you need to make a unit test that includes e.g. `config.Get().DisableHTMLTag` it is difficult to mock the config object. This is not friendly to unit-testing.

We rename `config` to `AppConfig` in `internal/pkg/config/config.go`. This way, its possible to use `AppConfig.DisableHTMLTag` in other modules and its easy to mock it in unit tests.

To showcase the new syntax, we change the HTML extractor to use the new `AppConfig`.

The old syntax isn't affected.