### PR TITLE
fix: missing text/css mimetype

### DIFF
--- a/pkg/models/mime_patch.go
+++ b/pkg/models/mime_patch.go
@@ -1,0 +1,22 @@
+package models
+
+import (
+	"sync"
+
+	"github.com/gabriel-vasile/mimetype"
+)
+
+var mimeExtendOnce sync.Once
+
+func extendMimetype() {
+	mimeExtendOnce.Do(func() {
+		mimePlaceholderFunc := func(raw []byte, limit uint32) bool {
+			return false
+		}
+
+		// https://github.com/gabriel-vasile/mimetype/pull/113
+		// gabriel-vasile/mimetype does not support CSS detection yet, so
+		// we have to extend a placeholder for our Content-Type lookup.
+		mimetype.Lookup("text/plain").Extend(mimePlaceholderFunc, "text/css", ".css")
+	})
+}

--- a/pkg/models/url.go
+++ b/pkg/models/url.go
@@ -86,6 +86,7 @@ func (u *URL) GetMIMEType() *mimetype.MIME {
 		if ct != "" {
 			mt, _, err := mime.ParseMediaType(strings.TrimSpace(ct))
 			if err == nil {
+				extendMimetype()
 				u.mimetype = mimetype.Lookup(mt)
 			}
 		}

--- a/pkg/models/url_test.go
+++ b/pkg/models/url_test.go
@@ -169,6 +169,7 @@ func TestMIMETypeMethods(t *testing.T) {
 		{"    text/html  ; charset=utf-8", "text/html"}, // random spaces
 		{"application/json; charset=utf-8", "application/json"},
 		{"Application/JSON;version=1", "application/json"}, // upper case mix
+		{"text/css", "text/css"},                           // extended MIME type
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
`gabriel-vasile/mimetype` does not support CSS detection yet, we have to extend a placeholder for our `Content-Type` lookup.