### PR TITLE
Improve GitHub archiving

### DIFF
--- a/internal/pkg/postprocessor/assets.go
+++ b/internal/pkg/postprocessor/assets.go
@@ -109,6 +109,8 @@ func extractAssets(item *models.Item) (assets, outlinks []*models.URL, err error
 		i++
 	}
 
+	assets, outlinks = filterURLsByProtocol(assets), filterURLsByProtocol(outlinks)
+
 	// For assets, set the hops level to the item's level
 	for _, asset := range assets {
 		asset.SetHops(item.GetURL().GetHops())

--- a/internal/pkg/postprocessor/extractor/html.go
+++ b/internal/pkg/postprocessor/extractor/html.go
@@ -282,8 +282,7 @@ func HTMLAssets(item *models.Item) (assets []*models.URL, err error) {
 				if strings.Contains(scriptType, "json") {
 					URLsFromJSON, _, err := GetURLsFromJSON(json.NewDecoder(strings.NewReader(i.Text())))
 					if err != nil {
-						// TODO: maybe add back when https://github.com/internetarchive/Zeno/issues/147 is fixed
-						// c.Log.Debug("unable to extract URLs from JSON in script tag", "error", err, "url", URL)
+						logger.Debug("unable to extract URLs from JSON in script tag", "error", err, "url", item.GetURL(), "item", item.GetShortID())
 					} else {
 						rawAssets = append(rawAssets, URLsFromJSON...)
 					}

--- a/internal/pkg/postprocessor/extractor/html.go
+++ b/internal/pkg/postprocessor/extractor/html.go
@@ -296,7 +296,7 @@ func HTMLAssets(item *models.Item) (assets []*models.URL, err error) {
 			} else {
 				var scriptLinks []string
 				if !config.Get().StrictRegex {
-					scriptLinks = utils.DedupeStrings(LinkRegex.FindAllString(outerHTML, -1))
+					scriptLinks = utils.DedupeStrings(QuotedLinkRegexFindAll(outerHTML))
 				} else {
 					scriptLinks = utils.DedupeStrings(LinkRegexStrict.FindAllString(outerHTML, -1))
 				}

--- a/internal/pkg/postprocessor/extractor/json.go
+++ b/internal/pkg/postprocessor/extractor/json.go
@@ -69,12 +69,22 @@ func findURLs(data interface{}, links *[]string) {
 	case string:
 		if isValidURL(v) {
 			*links = append(*links, v)
+			return
 		} else if isLikelyJSON(v) {
 			// handle JSON in JSON
 			var jsonstringdata interface{}
 			err := json.Unmarshal([]byte(v), &jsonstringdata)
 			if err == nil {
 				findURLs(jsonstringdata, links)
+				return
+			}
+		}
+
+		// find links in text
+		linlsFromText := LinkRegexStrict.FindAllString(v, -1)
+		for _, link := range linlsFromText {
+			if isValidURL(link) {
+				*links = append(*links, link)
 			}
 		}
 	case []interface{}:

--- a/internal/pkg/postprocessor/extractor/json.go
+++ b/internal/pkg/postprocessor/extractor/json.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/ImVexed/fasturl"
+	"github.com/internetarchive/Zeno/internal/pkg/postprocessor/sitespecific/github"
 	"github.com/internetarchive/Zeno/pkg/models"
 )
 
@@ -44,7 +45,7 @@ func GetURLsFromJSON(decoder *json.Decoder) (assets, outlinks []string, err erro
 
 	// We only consider as assets the URLs in which we can find a file extension
 	for _, link := range links {
-		if hasFileExtension(link) {
+		if hasFileExtension(link) || github.ShouldConsiderAsAsset(link) {
 			assets = append(assets, link)
 		} else {
 			outlinks = append(outlinks, link)

--- a/internal/pkg/postprocessor/extractor/json.go
+++ b/internal/pkg/postprocessor/extractor/json.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/ImVexed/fasturl"
+	"github.com/internetarchive/Zeno/internal/pkg/config"
 	"github.com/internetarchive/Zeno/internal/pkg/postprocessor/sitespecific/github"
 	"github.com/internetarchive/Zeno/pkg/models"
 )
@@ -82,7 +83,12 @@ func findURLs(data interface{}, links *[]string) {
 		}
 
 		// find links in text
-		linksFromText := LinkRegexStrict.FindAllString(v, -1)
+		var linksFromText []string
+		if !config.Get().StrictRegex {
+			linksFromText = LinkRegex.FindAllString(v, -1)
+		} else {
+			linksFromText = LinkRegexStrict.FindAllString(v, -1)
+		}
 		for _, link := range linksFromText {
 			if isValidURL(link) {
 				*links = append(*links, link)

--- a/internal/pkg/postprocessor/extractor/json.go
+++ b/internal/pkg/postprocessor/extractor/json.go
@@ -99,7 +99,26 @@ func findURLs(data interface{}, links *[]string) {
 	}
 }
 
+// This is a simplified version of the URL validation for quick checks.
 func isValidURL(str string) bool {
 	u, err := fasturl.ParseURL(str)
-	return err == nil && u.Host != ""
+	if err != nil {
+		return false
+	}
+
+	if u.Protocol == "" {
+		// If the URL does not have a protocol, we check if it has (a host) and (a path or query)
+		if u.Host != "" && (u.Path != "" || u.Query != "") {
+			// If the URL has a host and a path, it's valid
+			return true
+		}
+	} else {
+		// If the URL has a protocol and (a host), it's valid
+		if u.Host != "" {
+			return true
+		}
+	}
+
+	// Anything else is not a valid URL
+	return false
 }

--- a/internal/pkg/postprocessor/extractor/json.go
+++ b/internal/pkg/postprocessor/extractor/json.go
@@ -82,8 +82,8 @@ func findURLs(data interface{}, links *[]string) {
 		}
 
 		// find links in text
-		linlsFromText := LinkRegexStrict.FindAllString(v, -1)
-		for _, link := range linlsFromText {
+		linksFromText := LinkRegexStrict.FindAllString(v, -1)
+		for _, link := range linksFromText {
 			if isValidURL(link) {
 				*links = append(*links, link)
 			}

--- a/internal/pkg/postprocessor/extractor/json_test.go
+++ b/internal/pkg/postprocessor/extractor/json_test.go
@@ -7,21 +7,24 @@ import (
 	"os"
 	"testing"
 
+	"github.com/ImVexed/fasturl"
+	"github.com/davecgh/go-spew/spew"
 	"github.com/internetarchive/Zeno/internal/pkg/archiver"
 	"github.com/internetarchive/Zeno/pkg/models"
 )
 
 func TestJSON(t *testing.T) {
 	tests := []struct {
-		name     string
-		body     string
-		wantURLs []*models.URL
-		wantErr  bool
+		name         string
+		body         string
+		wantAssets   []*models.URL
+		wantOutlinks []*models.URL
+		wantErr      bool
 	}{
 		{
 			name: "JSON in script tag",
 			body: `{"ajaxurl":"http:\/\/fakeurl.invalid\/wp-admin\/admin-ajax.php","days":"Days","hours":"Hours","minutes":"Minutes","seconds":"Seconds","ajax_nonce":"c35d389da5"}`,
-			wantURLs: []*models.URL{
+			wantAssets: []*models.URL{
 				{Raw: "http://fakeurl.invalid/wp-admin/admin-ajax.php"},
 			},
 			wantErr: false,
@@ -29,28 +32,26 @@ func TestJSON(t *testing.T) {
 		{
 			name: "Valid JSON with URLs",
 			body: `{"url": "https://example.com", "nested": {"link": "http://test.com"}}`,
-			wantURLs: []*models.URL{
+			wantOutlinks: []*models.URL{
 				{Raw: "https://example.com"},
 				{Raw: "http://test.com"},
 			},
 			wantErr: false,
 		},
 		{
-			name:     "Invalid JSON",
-			body:     `{"url": "https://example.com"`,
-			wantURLs: nil,
-			wantErr:  true,
+			name:    "Invalid JSON",
+			body:    `{"url": "https://example.com"`,
+			wantErr: true,
 		},
 		{
-			name:     "JSON with no URLs",
-			body:     `{"key": "value", "number": 42}`,
-			wantURLs: nil,
-			wantErr:  false,
+			name:    "JSON with no URLs",
+			body:    `{"key": "value", "number": 42}`,
+			wantErr: false,
 		},
 		{
 			name: "JSON with URLs in various fields",
 			body: `{"someField": "https://example.com", "otherField": "http://test.com", "nested": {"deepLink": "https://deep.example.com"}}`,
-			wantURLs: []*models.URL{
+			wantOutlinks: []*models.URL{
 				{Raw: "https://example.com"},
 				{Raw: "http://test.com"},
 				{Raw: "https://deep.example.com"},
@@ -60,7 +61,7 @@ func TestJSON(t *testing.T) {
 		{
 			name: "JSON with array of URLs",
 			body: `{"links": ["https://example1.com", "https://example2.com"]}`,
-			wantURLs: []*models.URL{
+			wantOutlinks: []*models.URL{
 				{Raw: "https://example1.com"},
 				{Raw: "https://example2.com"},
 			},
@@ -69,7 +70,7 @@ func TestJSON(t *testing.T) {
 		{
 			name: "JSON in JSON string",
 			body: `{"dic": "{\"url\": \"https://example1.com\"}", "array": "[\"https://example2.com\"]"}`,
-			wantURLs: []*models.URL{
+			wantOutlinks: []*models.URL{
 				{Raw: "https://example1.com"},
 				{Raw: "https://example2.com"},
 			},
@@ -78,7 +79,7 @@ func TestJSON(t *testing.T) {
 		{
 			name: "URLs in text fields",
 			body: `{"body": "Check this link https://example.com and also http://test.com"}`,
-			wantURLs: []*models.URL{
+			wantOutlinks: []*models.URL{
 				{Raw: "https://example.com"},
 				{Raw: "http://test.com"},
 			},
@@ -102,7 +103,7 @@ func TestJSON(t *testing.T) {
 				t.Errorf("ProcessBody() error = %v", err)
 			}
 
-			assets, _, err := JSON(URL)
+			assets, outlinks, err := JSON(URL)
 
 			if (err != nil) != tt.wantErr {
 				t.Errorf("JSON() error = %v, wantErr %v", err, tt.wantErr)
@@ -111,16 +112,55 @@ func TestJSON(t *testing.T) {
 
 			// Sort both slices before comparison
 			sortURLs(assets)
-			sortURLs(tt.wantURLs)
+			sortURLs(tt.wantAssets)
+			sortURLs(outlinks)
+			sortURLs(tt.wantOutlinks)
 
-			if len(assets) != len(tt.wantURLs) {
-				t.Fatalf("Expected %d URLs, got %d", len(tt.wantURLs), len(assets))
+			if len(assets) != len(tt.wantAssets) {
+				t.Fatalf("Expected %d Assets, got %d", len(tt.wantAssets), len(assets))
 			}
 
 			for i := range assets {
-				if assets[i].Raw != tt.wantURLs[i].Raw {
-					t.Errorf("Expected URL %s, got %s", tt.wantURLs[i].Raw, assets[i].Raw)
+				if assets[i].Raw != tt.wantAssets[i].Raw {
+					t.Errorf("Expected URL %s, got %s", tt.wantAssets[i].Raw, assets[i].Raw)
 				}
+			}
+
+			if len(outlinks) != len(tt.wantOutlinks) {
+				t.Fatalf("Expected %d Outlinks, got %d", len(tt.wantOutlinks), len(outlinks))
+			}
+
+			for i := range outlinks {
+				if outlinks[i].Raw != tt.wantOutlinks[i].Raw {
+					t.Errorf("Expected Outlink %s, got %s", tt.wantOutlinks[i].Raw, outlinks[i].Raw)
+				}
+			}
+		})
+	}
+}
+
+func TestIsValidURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		expected bool
+	}{
+		{"Valid URL", "https://example.com", true},
+		{"URL with spaces", "http://example.com/some path", true},
+		{"URL with special characters", "http://example.com/some?query=param&another=param", true},
+		{"hostname with path", "example.com/path/to/resource", true},
+		{"Invalid URL", "not a url", false},
+		{"Empty String", "", false},
+		{"A Word", "Days", false},
+		{"Hostname with query", "example.com?query=param", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isValidURL(tt.url)
+			if result != tt.expected {
+				t.Errorf("isValidURL(%q) = %v; want %v", tt.url, result, tt.expected)
+				spew.Dump(fasturl.ParseURL(tt.url))
 			}
 		})
 	}

--- a/internal/pkg/postprocessor/extractor/json_test.go
+++ b/internal/pkg/postprocessor/extractor/json_test.go
@@ -75,12 +75,21 @@ func TestJSON(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "URLs in text fields",
+			body: `{"body": "Check this link https://example.com and also http://test.com"}`,
+			wantURLs: []*models.URL{
+				{Raw: "https://example.com"},
+				{Raw: "http://test.com"},
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			resp := &http.Response{
-				Body: io.NopCloser(bytes.NewBufferString(tt.body)),
+				Body:   io.NopCloser(bytes.NewBufferString(tt.body)),
 				Header: make(http.Header),
 			}
 			resp.Header.Set("Content-Type", "application/json")

--- a/internal/pkg/postprocessor/extractor/utils.go
+++ b/internal/pkg/postprocessor/extractor/utils.go
@@ -19,7 +19,7 @@ var (
 // It might yield false positives, like https://example.com/super.idea,
 // but it's good enough for our purposes.
 func hasFileExtension(s string) bool {
-	// Remove query and fragment portion (#...)
+	// Remove query and fragment portion (?...) (#...)
 	if i := strings.IndexAny(s, `?#`); i != -1 {
 		s = s[:i]
 	}

--- a/internal/pkg/postprocessor/extractor/utils.go
+++ b/internal/pkg/postprocessor/extractor/utils.go
@@ -19,13 +19,14 @@ var (
 // It might yield false positives, like https://example.com/super.idea,
 // but it's good enough for our purposes.
 func hasFileExtension(s string) bool {
-	// Remove fragment portion (#...)
-	if i := strings.IndexByte(s, '#'); i != -1 {
+	// Remove query and fragment portion (#...)
+	if i := strings.IndexAny(s, `?#`); i != -1 {
 		s = s[:i]
 	}
-	// Remove query portion (?...)
-	if i := strings.IndexByte(s, '?'); i != -1 {
-		s = s[:i]
+
+	// Exclude URLs that only contain a protocol and domain
+	if (strings.HasPrefix(s, "//") || strings.Contains(s, "://")) && strings.Count(s, "/") == 2 {
+		return false // e.g., "//example.com", "http://example.com"
 	}
 
 	// Keep only the substring after the last slash

--- a/internal/pkg/postprocessor/extractor/utils.go
+++ b/internal/pkg/postprocessor/extractor/utils.go
@@ -11,9 +11,22 @@ import (
 
 var (
 	LinkRegexStrict = xurls.Strict()
-	LinkRegex       = regexp.MustCompile(`['"]((http|https)://[^'"]+)['"]`)
+	LinkRegex       = regexp.MustCompile(`(?i)https?://[^<>'",\s/]+\.[^<>'",\s/]+(?:/[^<>'",\s]*)?`) // Adapted from heritrix3's UriUtils (Apache License 2.0)
+	quotedLinkRegex = regexp.MustCompile(`['"](https?://[^'"]+)['"]`)
 	AssetsRegex     = `(?i)\b(?:src|href)=["']([^"']+\.(?:css|js|png|jpg|jpeg|gif|svg|webp|woff|woff2|ttf|eot))["']`
 )
+
+// Helper function to call FindAllStringSubmatch on quotedLinkRegex and return only the capturing group (Quoted URL).
+func QuotedLinkRegexFindAll(s string) []string {
+	matches := quotedLinkRegex.FindAllStringSubmatch(s, -1)
+	result := make([]string, 0, len(matches))
+	for i := range matches {
+		if len(matches[i]) > 1 {
+			result = append(result, matches[i][1])
+		}
+	}
+	return result
+}
 
 // hasFileExtension checks if a URL has a file extension in it.
 // It might yield false positives, like https://example.com/super.idea,

--- a/internal/pkg/postprocessor/extractor/utils_test.go
+++ b/internal/pkg/postprocessor/extractor/utils_test.go
@@ -98,6 +98,16 @@ func TestHasFileExtension(t *testing.T) {
 			input: "http://example.com/data.zip?path=/etc/passwd",
 			want:  true,
 		},
+		{
+			name:  "Protocol and domain only, no path",
+			input: "https://example.com",
+			want:  false,
+		},
+		{
+			name:  "Protocol and domain with trailing slash",
+			input: "https://example.com/",
+			want:  false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/pkg/postprocessor/extractor/utils_test.go
+++ b/internal/pkg/postprocessor/extractor/utils_test.go
@@ -1,6 +1,9 @@
 package extractor
 
-import "testing"
+import (
+	"slices"
+	"testing"
+)
 
 func TestHasFileExtension(t *testing.T) {
 	tests := []struct {
@@ -115,6 +118,117 @@ func TestHasFileExtension(t *testing.T) {
 			got := hasFileExtension(tt.input)
 			if got != tt.want {
 				t.Errorf("hasFileExtension(%q) = %v; want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLinkRegex(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "Valid URL",
+			input:    "Check this link: https://example.com",
+			expected: []string{"https://example.com"},
+		},
+		{
+			name:     "Multiple URLs",
+			input:    "Links: http://example.com, https://test.org/path",
+			expected: []string{"http://example.com", "https://test.org/path"},
+		},
+		{
+			name:     "No URLs",
+			input:    "Just some text without links.",
+			expected: []string{},
+		},
+		{
+			name:     "Bare domain without protocol",
+			input:    "This is not a valid link: example.com",
+			expected: []string{},
+		},
+		{
+			name:     "URL",
+			input:    "This is a link: https://example.com/path/to/resource?query=param#fragment and some text.",
+			expected: []string{"https://example.com/path/to/resource?query=param#fragment"},
+		},
+		{
+			name:  "Markdown-style link",
+			input: "Check this [link](https://example.com/1.html) for more info. details: <https://example.com/2.html>",
+			expected: []string{
+				"https://example.com/1.html)", // <-- This is a trade-off, if I let the regex to ignore the closing parenthesis,
+				// it will not match the below "Wikipedia URL" case correctly.
+				// But [LinkRegexStrict] would match both URLs correctly, IDK how it works unfortunately :(
+				"https://example.com/2.html",
+			},
+		},
+		{
+			name:     "Wikipedia URL",
+			input:    "page: https://en.wikipedia.org/wiki/Pipeline_(Unix) and some text.",
+			expected: []string{"https://en.wikipedia.org/wiki/Pipeline_(Unix)"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := LinkRegex.FindAllString(tt.input, -1)
+			if len(result) != len(tt.expected) {
+				t.Errorf("Expected %d URLs, got %d", len(tt.expected), len(result))
+				return
+			}
+			slices.Sort(result)
+			slices.Sort(tt.expected)
+			for i, url := range result {
+				if url != tt.expected[i] {
+					t.Errorf("Expected URL %s, got %s", tt.expected[i], url)
+				}
+			}
+		})
+	}
+}
+
+func TestQuotedLinkRegex(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "Quoted URL",
+			input:    `Check this link: 'https://example.com'`,
+			expected: []string{"https://example.com"},
+		},
+		{
+			name:     "Multiple quoted URLs",
+			input:    `Links: "http://example.com", "https://test.org/path"`,
+			expected: []string{"http://example.com", "https://test.org/path"},
+		},
+		{
+			name:  "No quoted URLs",
+			input: `Just some text without links.`,
+		},
+		{
+			name:  "Unquoted URL",
+			input: `This is not a valid link: https://example.com`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := QuotedLinkRegexFindAll(tt.input)
+			if len(result) != len(tt.expected) {
+				t.Errorf("Expected %d quoted URLs, got %d", len(tt.expected), len(result))
+				return
+			}
+
+			slices.Sort(result)
+			slices.Sort(tt.expected)
+			for i, url := range result {
+				if url != tt.expected[i] {
+					t.Errorf("Expected quoted URL %s, got %s", tt.expected[i], url)
+				}
 			}
 		})
 	}

--- a/internal/pkg/postprocessor/extractor/xml_test.go
+++ b/internal/pkg/postprocessor/extractor/xml_test.go
@@ -148,9 +148,9 @@ func TestXML(t *testing.T) {
 			body: rss2_0XML,
 			expected: func() []string {
 				v := make([]string, 213)
-				v[1] = "https://blog.archive.org/wp-content/uploads/2023/03/ia-logo-sq-150x150.png"             // image::url
-				v[13] = "https://blog.archive.org/wp-content/uploads/2025/03/Vanishing-Culture-Prelinger-3.png" // <a> href in description::CDATA
-				v[181] = "https://archive.org/details/vanishing-culture-report"
+				v[0] = "https://blog.archive.org/wp-content/uploads/2023/03/ia-logo-sq-150x150.png"             // image::url
+				v[11] = "https://blog.archive.org/wp-content/uploads/2025/03/Vanishing-Culture-Prelinger-3.png" // <a> href in description::CDATA
+				v[212] = "https://blog.archive.org/2025/02/06/update-on-the-2024-2025-end-of-term-web-archive/feed/"
 				return v
 
 			}(),
@@ -161,7 +161,7 @@ func TestXML(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			resp := &http.Response{
-				Body: io.NopCloser(bytes.NewBufferString(tt.body)),
+				Body:   io.NopCloser(bytes.NewBufferString(tt.body)),
 				Header: make(http.Header),
 			}
 			resp.Header.Set("Content-Type", "application/xml")

--- a/internal/pkg/postprocessor/outlinks.go
+++ b/internal/pkg/postprocessor/outlinks.go
@@ -2,7 +2,6 @@ package postprocessor
 
 import (
 	"io"
-	"regexp"
 	"strings"
 
 	"github.com/internetarchive/Zeno/internal/pkg/config"
@@ -13,10 +12,6 @@ import (
 	"github.com/internetarchive/Zeno/internal/pkg/postprocessor/sitespecific/truthsocial"
 	"github.com/internetarchive/Zeno/internal/pkg/utils"
 	"github.com/internetarchive/Zeno/pkg/models"
-)
-
-var (
-	skipProtocolsRe = regexp.MustCompile(`(?i)^(data|file|javascript|mailto|sms|tel):`)
 )
 
 func extractOutlinks(item *models.Item) (outlinks []*models.URL, err error) {
@@ -131,16 +126,6 @@ func extractLinksFromPage(URL *models.URL) (links []*models.URL) {
 	}
 
 	return links
-}
-
-func filterURLsByProtocol(links []*models.URL) []*models.URL {
-	var filtered []*models.URL
-	for _, link := range links {
-		if !skipProtocolsRe.MatchString(link.Raw) {
-			filtered = append(filtered, link)
-		}
-	}
-	return filtered
 }
 
 func shouldExtractOutlinks(item *models.Item) bool {

--- a/internal/pkg/postprocessor/sitespecific/github/github.go
+++ b/internal/pkg/postprocessor/sitespecific/github/github.go
@@ -15,22 +15,22 @@ var logger = log.NewFieldedLogger(&log.Fields{
 var githubAvatar = regexp.MustCompile(`(?i)^https://avatars\.githubusercontent\.com/u/`)
 
 // github frontend .css .js resources
-var githubAssets = regexp.MustCompile(`(?i)^https://github\.githubassets\.com/`)
+var githubFrontendAssets = regexp.MustCompile(`(?i)^https://github\.githubassets\.com/`)
 
 // Attachment links shown to the user in the editor
-var githubUserAttachments = regexp.MustCompile(`(?i)^https://github\.com/user-attachments/`)
+var githubComUserAttachments = regexp.MustCompile(`(?i)^https://github\.com/user-attachments/`)
 
 // Permanent links to attachments
-var regexGithubAsset = regexp.MustCompile(`(?i)https://github\.com/[^/]+/[^/]+/assets/`)
+var githubComAssets = regexp.MustCompile(`(?i)https://github\.com/[^/]+/[^/]+/assets/`)
 
 // Temporary links to attachments
 var githubPrivateUserImages = regexp.MustCompile(`(?i)^https://private-user-images\.githubusercontent\.com/`)
 
 var matchers = []*regexp.Regexp{
 	githubAvatar,
-	githubAssets,
-	githubUserAttachments,
-	regexGithubAsset,
+	githubFrontendAssets,
+	githubComUserAttachments,
+	githubComAssets,
 	githubPrivateUserImages,
 }
 

--- a/internal/pkg/postprocessor/sitespecific/github/github.go
+++ b/internal/pkg/postprocessor/sitespecific/github/github.go
@@ -12,21 +12,21 @@ var logger = log.NewFieldedLogger(&log.Fields{
 })
 
 // user avatars
-var githubAvatar = "avatars.githubusercontent.com/u/"
+var githubAvatar = regexp.MustCompile(`(?i)^https://avatars\.githubusercontent\.com/u/`)
 
 // github frontend .css .js resources
-var githubAssets = "github.githubassets.com/"
+var githubAssets = regexp.MustCompile(`(?i)^https://github\.githubassets\.com/`)
 
 // Attachment links shown to the user in the editor
-var githubUserAttachments = "github.com/user-attachments/"
+var githubUserAttachments = regexp.MustCompile(`(?i)^https://github\.com/user-attachments/`)
 
 // Permanent links to attachments
 var regexGithubAsset = regexp.MustCompile(`(?i)https://github\.com/[^/]+/[^/]+/assets/`)
 
 // Temporary links to attachments
-var githubPrivateUserImages = "private-user-images.githubusercontent.com/"
+var githubPrivateUserImages = regexp.MustCompile(`(?i)^https://private-user-images\.githubusercontent\.com/`)
 
-var matchers []any = []any{
+var matchers = []*regexp.Regexp{
 	githubAvatar,
 	githubAssets,
 	githubUserAttachments,
@@ -41,18 +41,10 @@ func ShouldConsiderAsAsset(u string) bool {
 		return false
 	}
 
-	for _, matcher := range matchers {
-		switch m := matcher.(type) {
-		case string:
-			if strings.Contains(u, m) {
-				logger.Debug("matched GitHub asset pattern", "pattern", m, "url", u)
-				return true
-			}
-		case *regexp.Regexp:
-			if m.MatchString(u) {
-				logger.Debug("matched GitHub asset pattern", "pattern", m.String(), "url", u)
-				return true
-			}
+	for i := range matchers {
+		if matchers[i].MatchString(u) {
+			logger.Debug("matched GitHub asset pattern", "pattern", matchers[i].String(), "url", u)
+			return true
 		}
 	}
 

--- a/internal/pkg/postprocessor/sitespecific/github/github.go
+++ b/internal/pkg/postprocessor/sitespecific/github/github.go
@@ -11,11 +11,10 @@ var logger = log.NewFieldedLogger(&log.Fields{
 	"component": "postprocessor.sitespecific.github",
 })
 
-// user avatars
-var githubAvatar = regexp.MustCompile(`(?i)^https://avatars\.githubusercontent\.com/u/`)
-
-// github frontend .css .js resources
-var githubFrontendAssets = regexp.MustCompile(`(?i)^https://github\.githubassets\.com/`)
+// User avatars: avatars.githubusercontent.com
+// Temporary link to attachments: private-user-images.githubusercontent.com
+// Github frontend .css .js resources: github.githubassets.com
+var githubAssetsDomains = regexp.MustCompile(`(?i)^https://[a-z-]*\.?(?:githubusercontent|githubassets)\.com/`)
 
 // Attachment links shown to the user in the editor
 var githubComUserAttachments = regexp.MustCompile(`(?i)^https://github\.com/user-attachments/`)
@@ -23,15 +22,10 @@ var githubComUserAttachments = regexp.MustCompile(`(?i)^https://github\.com/user
 // Permanent links to attachments
 var githubComAssets = regexp.MustCompile(`(?i)https://github\.com/[^/]+/[^/]+/assets/`)
 
-// Temporary links to attachments
-var githubPrivateUserImages = regexp.MustCompile(`(?i)^https://private-user-images\.githubusercontent\.com/`)
-
 var matchers = []*regexp.Regexp{
-	githubAvatar,
-	githubFrontendAssets,
+	githubAssetsDomains,
 	githubComUserAttachments,
 	githubComAssets,
-	githubPrivateUserImages,
 }
 
 // Many GitHub asset urls do not have a file extension, so we need to consider

--- a/internal/pkg/postprocessor/sitespecific/github/github.go
+++ b/internal/pkg/postprocessor/sitespecific/github/github.go
@@ -1,0 +1,60 @@
+package github
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/internetarchive/Zeno/internal/pkg/log"
+)
+
+var logger = log.NewFieldedLogger(&log.Fields{
+	"component": "postprocessor.sitespecific.github",
+})
+
+// user avatars
+var githubAvatar = "avatars.githubusercontent.com/u/"
+
+// github frontend .css .js resources
+var githubAssets = "github.githubassets.com/"
+
+// Attachment links shown to the user in the editor
+var githubUserAttachments = "github.com/user-attachments/"
+
+// Permanent links to attachments
+var regexGithubAsset = regexp.MustCompile(`(?i)https://github\.com/[^/]+/[^/]+/assets/`)
+
+// Temporary links to attachments
+var githubPrivateUserImages = "private-user-images.githubusercontent.com/"
+
+var matchers []any = []any{
+	githubAvatar,
+	githubAssets,
+	githubUserAttachments,
+	regexGithubAsset,
+	githubPrivateUserImages,
+}
+
+// Many GitHub asset urls do not have a file extension, so we need to consider
+// some specific patterns to identify them as assets.
+func ShouldConsiderAsAsset(u string) bool {
+	if !strings.Contains(u, "github") {
+		return false
+	}
+
+	for _, matcher := range matchers {
+		switch m := matcher.(type) {
+		case string:
+			if strings.Contains(u, m) {
+				logger.Debug("matched GitHub asset pattern", "pattern", m, "url", u)
+				return true
+			}
+		case *regexp.Regexp:
+			if m.MatchString(u) {
+				logger.Debug("matched GitHub asset pattern", "pattern", m.String(), "url", u)
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/internal/pkg/postprocessor/sitespecific/github/github_test.go
+++ b/internal/pkg/postprocessor/sitespecific/github/github_test.go
@@ -15,6 +15,7 @@ func TestShouldConsiderAsAsset(t *testing.T) {
 
 		{"https://example.com/image.png", false},
 		{"https://notgithub.com/image.png", false},
+		{"Seconds", false}, // Invalid URL
 	}
 
 	for _, c := range cases {

--- a/internal/pkg/postprocessor/sitespecific/github/github_test.go
+++ b/internal/pkg/postprocessor/sitespecific/github/github_test.go
@@ -16,6 +16,8 @@ func TestShouldConsiderAsAsset(t *testing.T) {
 		{"https://example.com/image.png", false},
 		{"https://notgithub.com/image.png", false},
 		{"Seconds", false}, // Invalid URL
+		{"https://github.com/internetarchive", false},
+		{"https://github.com/internetarchive/zeno", false},
 	}
 
 	for _, c := range cases {

--- a/internal/pkg/postprocessor/sitespecific/github/github_test.go
+++ b/internal/pkg/postprocessor/sitespecific/github/github_test.go
@@ -1,0 +1,28 @@
+package github
+
+import "testing"
+
+func TestShouldConsiderAsAsset(t *testing.T) {
+	cases := []struct {
+		url      string
+		expected bool
+	}{
+		{"https://avatars.githubusercontent.com/u/12345", true},
+		{"https://github.githubassets.com/some-asset", true},
+		{"https://github.com/user-attachments/file", true},
+		{"https://github.com/user-or-org/repo/assets/image", true},
+		{"https://private-user-images.githubusercontent.com/image", true},
+
+		{"https://example.com/image.png", false},
+		{"https://notgithub.com/image.png", false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.url, func(t *testing.T) {
+			result := ShouldConsiderAsAsset(c.url)
+			if result != c.expected {
+				t.Errorf("ShouldConsiderAsAsset(%q) = %v; want %v", c.url, result, c.expected)
+			}
+		})
+	}
+}

--- a/internal/pkg/postprocessor/utils.go
+++ b/internal/pkg/postprocessor/utils.go
@@ -1,5 +1,15 @@
 package postprocessor
 
+import (
+	"regexp"
+
+	"github.com/internetarchive/Zeno/pkg/models"
+)
+
+var (
+	skipProtocolsRe = regexp.MustCompile(`(?i)^(data|file|javascript|mailto|sms|tel):`)
+)
+
 func isStatusCodeRedirect(statusCode int) bool {
 	switch statusCode {
 	case 300, 301, 302, 303, 307, 308:
@@ -7,4 +17,14 @@ func isStatusCodeRedirect(statusCode int) bool {
 	default:
 		return false
 	}
+}
+
+func filterURLsByProtocol(links []*models.URL) []*models.URL {
+	var filtered []*models.URL
+	for _, link := range links {
+		if !skipProtocolsRe.MatchString(link.Raw) {
+			filtered = append(filtered, link)
+		}
+	}
+	return filtered
 }


### PR DESCRIPTION
Improved the archiving quality of GitHub Issue&PR pages.

26e6dd2ad74420cea746b3b87449fccbf58c8a10, f94197f5947a1030422e86256e398d4f18467af0 fix:
I noticed that some "data:" URLs were being queued that should have been filtered => We forgot to call `filterURLsByProtocol()` for assets.

e543bb3cd6149f060f2a2eb39034e9b0c15a10b0 fix:
GitHub has rewritten the issue pages in react in recent months. Now they embed many useful (images, videos, user avatars...) assets into HTML `<script>` tags as JSON for issue pages.
![image](https://github.com/user-attachments/assets/dc3a0b58-066e-4d1d-a81d-9a4b98ab9b69)

These assets are in JSON strings.
![image](https://github.com/user-attachments/assets/39669b14-5445-4f39-b140-909c21272569)

and JSON extractor currently only considers an asset if the entire string is a valid URL.

49de5c7e086a34b2ed81ba6581a8fe526069483b improved:
These GitHub assets have no file suffix, so a `sitespecific/github.go` patch was added to JSON extractor to treat them as assets.

daa9ee819535eef58eeb5c5e68de9c722fd2e224 fix:
`hasFileExtension()` wrongly considers _Protocol and domain only, no path_ links like `https://example.com` to have a suffix.

92241c78374d186bad449ecdc6962d7b9143fe93: make `isValidURL()` check more robust

fe3f888 Chnaged: Renamed the original `LinkRegex` to `QuotedLinkRegex` to reflect its actual purpose. The new `LinkRegex` is copyied and adapted from heritrix3. :)