### PR TITLE
Remove redundant code in domainscrawl

### DIFF
--- a/internal/pkg/postprocessor/domainscrawl/domainscrawl.go
+++ b/internal/pkg/postprocessor/domainscrawl/domainscrawl.go
@@ -52,9 +52,7 @@ func AddElements(elements []string) error {
 	globalMatcher.Lock()
 	defer globalMatcher.Unlock()
 
-	if !globalMatcher.enabled {
-		globalMatcher.enabled = true
-	}
+	globalMatcher.enabled = true
 
 	for _, element := range elements {
 		// Try to parse as a URL first


### PR DESCRIPTION
This code checks if `globalMatcher.enabled` is false and it sets it to true. This means that `globalMatcher.enabled` should be always just true.