### PR TITLE
Implement `CheckDiskUsage()` for Windows

### DIFF
--- a/internal/pkg/controler/watchers/disk.go
+++ b/internal/pkg/controler/watchers/disk.go
@@ -4,10 +4,8 @@ import (
 	"context"
 	"fmt"
 	"sync"
-	"syscall"
 	"time"
 
-	"github.com/internetarchive/Zeno/internal/pkg/config"
 	"github.com/internetarchive/Zeno/internal/pkg/controler/pause"
 	"github.com/internetarchive/Zeno/internal/pkg/log"
 )
@@ -40,18 +38,6 @@ func checkThreshold(total, free uint64, minSpaceRequired float64) error {
 	}
 
 	return nil
-}
-
-func CheckDiskUsage(path string) error {
-	var stat syscall.Statfs_t
-	if err := syscall.Statfs(path, &stat); err != nil {
-		panic(fmt.Sprintf("Error retrieving disk stats: %v\n", err))
-	}
-
-	total := stat.Blocks * uint64(stat.Bsize)
-	free := stat.Bavail * uint64(stat.Bsize)
-
-	return checkThreshold(total, free, config.Get().MinSpaceRequired)
 }
 
 // WatchDiskSpace watches the disk space and pauses the pipeline if it's low

--- a/internal/pkg/controler/watchers/disk_unix.go
+++ b/internal/pkg/controler/watchers/disk_unix.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+package watchers
+
+import (
+	"fmt"
+	"syscall"
+
+	"github.com/internetarchive/Zeno/internal/pkg/config"
+)
+
+func CheckDiskUsage(path string) error {
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs(path, &stat); err != nil {
+		panic(fmt.Sprintf("Error retrieving disk stats: %v\n", err))
+	}
+
+	total := stat.Blocks * uint64(stat.Bsize)
+	free := stat.Bavail * uint64(stat.Bsize)
+
+	return checkThreshold(total, free, config.Get().MinSpaceRequired)
+}

--- a/internal/pkg/controler/watchers/disk_windows.go
+++ b/internal/pkg/controler/watchers/disk_windows.go
@@ -1,0 +1,20 @@
+//go:build windows
+
+package watchers
+
+import (
+	"fmt"
+
+	"github.com/internetarchive/Zeno/internal/pkg/config"
+	"golang.org/x/sys/windows"
+)
+
+func CheckDiskUsage(path string) error {
+	var freeBytesAvailable uint64
+	var totalNumberOfBytes uint64
+	var totalNumberOfFreeBytes uint64
+	if err := windows.GetDiskFreeSpaceEx(windows.StringToUTF16Ptr(path), &freeBytesAvailable, &totalNumberOfBytes, &totalNumberOfFreeBytes); err != nil {
+		panic(fmt.Sprintf("Error retrieving disk stats: %v\n", err))
+	}
+	return checkThreshold(totalNumberOfBytes, freeBytesAvailable, config.Get().MinSpaceRequired)
+}


### PR DESCRIPTION
#245

resolve: _Zeno's diskwatcher only uses linux syscall to get the free space size of the PWD._