### PR TITLE
Implement a shared interface for `source` so anyone can implement their own source of items

### DIFF
--- a/internal/pkg/controler/pipeline.go
+++ b/internal/pkg/controler/pipeline.go
@@ -16,11 +16,13 @@ import (
 	"github.com/internetarchive/Zeno/internal/pkg/preprocessor"
 	"github.com/internetarchive/Zeno/internal/pkg/preprocessor/seencheck"
 	"github.com/internetarchive/Zeno/internal/pkg/reactor"
+	"github.com/internetarchive/Zeno/internal/pkg/source"
 	"github.com/internetarchive/Zeno/internal/pkg/source/hq"
-	"github.com/internetarchive/Zeno/internal/pkg/source/lq"
 	"github.com/internetarchive/Zeno/internal/pkg/stats"
 	"github.com/internetarchive/Zeno/pkg/models"
 )
+
+var sourceInterface source.Source
 
 /**
  * Channel description:
@@ -120,20 +122,44 @@ func startPipeline() {
 	finisherProduceChan := makeStageChannel(config.Get().WorkersCount)
 
 	if config.Get().UseHQ {
-		logger.Info("starting hq")
-		err = hq.Start(finisherFinishChan, finisherProduceChan)
-		if err != nil {
-			logger.Error("error starting hq source, retrying", "err", err.Error())
-			panic(err)
-		}
-	} else {
-		logger.Info("starting local queue")
-		err = lq.Start(finisherFinishChan, finisherProduceChan)
-		if err != nil {
-			logger.Error("error starting local queue source", "err", err.Error())
-			panic(err)
-		}
+		hqSource := hq.New()
+		preprocessor.SetSeenchecker(hqSource.SeencheckItem)
+		sourceInterface = hqSource
 	}
+	// } else {
+	// 	lqSource := lq.New()
+	// 	if config.Get().UseSeencheck {
+	// 		// If we are using seencheck, we need to set it in the local queue
+	// 		lqSource.SetSeenchecker(seencheck.SeencheckItem)
+	// 	} else {
+	// 		// If we are not using seencheck, we can use the local queue without it
+	// 		lqSource.SetSeenchecker(nil)
+	// 	}
+	// 	source = lqSource
+	// }
+
+	err = sourceInterface.Start(finisherFinishChan, finisherProduceChan)
+	if err != nil {
+		logger.Error("error starting source", "source", sourceInterface.Name(), "err", err.Error())
+		panic(err)
+	}
+
+	// if config.Get().UseHQ {
+	// 	logger.Info("starting hq")
+	// 	hq.New()
+	// 	err = hq.Start(finisherFinishChan, finisherProduceChan)
+	// 	if err != nil {
+	// 		logger.Error("error starting hq source, retrying", "err", err.Error())
+	// 		panic(err)
+	// 	}
+	// } else {
+	// 	logger.Info("starting local queue")
+	// 	err = lq.Start(finisherFinishChan, finisherProduceChan)
+	// 	if err != nil {
+	// 		logger.Error("error starting local queue source", "err", err.Error())
+	// 		panic(err)
+	// 	}
+	// }
 
 	err = finisher.Start(postprocessorOutputChan, finisherFinishChan, finisherProduceChan)
 	if err != nil {
@@ -180,11 +206,7 @@ func stopPipeline() {
 		seencheck.Close()
 	}
 
-	if config.Get().UseHQ {
-		hq.Stop()
-	} else {
-		lq.Stop()
-	}
+	sourceInterface.Stop()
 
 	reactor.Stop()
 

--- a/internal/pkg/controler/pipeline.go
+++ b/internal/pkg/controler/pipeline.go
@@ -18,6 +18,7 @@ import (
 	"github.com/internetarchive/Zeno/internal/pkg/reactor"
 	"github.com/internetarchive/Zeno/internal/pkg/source"
 	"github.com/internetarchive/Zeno/internal/pkg/source/hq"
+	"github.com/internetarchive/Zeno/internal/pkg/source/lq"
 	"github.com/internetarchive/Zeno/internal/pkg/stats"
 	"github.com/internetarchive/Zeno/pkg/models"
 )
@@ -125,41 +126,20 @@ func startPipeline() {
 		hqSource := hq.New()
 		preprocessor.SetSeenchecker(hqSource.SeencheckItem)
 		sourceInterface = hqSource
+	} else {
+		lqSource := lq.New()
+		if config.Get().UseSeencheck {
+			preprocessor.SetSeenchecker(seencheck.SeencheckItem)
+		}
+		sourceInterface = lqSource
 	}
-	// } else {
-	// 	lqSource := lq.New()
-	// 	if config.Get().UseSeencheck {
-	// 		// If we are using seencheck, we need to set it in the local queue
-	// 		lqSource.SetSeenchecker(seencheck.SeencheckItem)
-	// 	} else {
-	// 		// If we are not using seencheck, we can use the local queue without it
-	// 		lqSource.SetSeenchecker(nil)
-	// 	}
-	// 	source = lqSource
-	// }
 
+	logger.Info("starting source", "source", sourceInterface.Name())
 	err = sourceInterface.Start(finisherFinishChan, finisherProduceChan)
 	if err != nil {
 		logger.Error("error starting source", "source", sourceInterface.Name(), "err", err.Error())
 		panic(err)
 	}
-
-	// if config.Get().UseHQ {
-	// 	logger.Info("starting hq")
-	// 	hq.New()
-	// 	err = hq.Start(finisherFinishChan, finisherProduceChan)
-	// 	if err != nil {
-	// 		logger.Error("error starting hq source, retrying", "err", err.Error())
-	// 		panic(err)
-	// 	}
-	// } else {
-	// 	logger.Info("starting local queue")
-	// 	err = lq.Start(finisherFinishChan, finisherProduceChan)
-	// 	if err != nil {
-	// 		logger.Error("error starting local queue source", "err", err.Error())
-	// 		panic(err)
-	// 	}
-	// }
 
 	err = finisher.Start(postprocessorOutputChan, finisherFinishChan, finisherProduceChan)
 	if err != nil {

--- a/internal/pkg/source/hq/seencheck.go
+++ b/internal/pkg/source/hq/seencheck.go
@@ -9,7 +9,7 @@ import (
 
 // SeencheckItem gets the MaxDepth children of the given item and sends a seencheck request to the crawl HQ for the URLs found.
 // The items that were seen before will be marked as seen.
-func SeencheckItem(item *models.Item) error {
+func (s *HQ) SeencheckItem(item *models.Item) error {
 	var URLsToSeencheck []gocrawlhq.URL
 
 	items, err := item.GetNodesAtLevel(item.GetMaxDepth())
@@ -56,7 +56,7 @@ func SeencheckItem(item *models.Item) error {
 
 	// Get seencheck URLs from CrawlHQ
 	// If an URL is not returned it means that it was seen before
-	outputURLs, err := globalHQ.client.Seencheck(context.TODO(), URLsToSeencheck)
+	outputURLs, err := s.client.Seencheck(context.TODO(), URLsToSeencheck)
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/source/hq/websocket.go
+++ b/internal/pkg/source/hq/websocket.go
@@ -13,7 +13,7 @@ import (
 // It also sends and "identify" message to the HQ to let it know that
 // Zeno is connected. This "identify" message is sent every second and
 // contains the crawler's stats and details.
-func websocket() {
+func (s *HQ) websocket() {
 	logger := log.NewFieldedLogger(&log.Fields{
 		"component": "hq.websocket",
 	})
@@ -23,19 +23,19 @@ func websocket() {
 
 	for {
 		select {
-		case <-globalHQ.ctx.Done():
+		case <-s.ctx.Done():
 			logger.Debug("received done signal")
-			globalHQ.wg.Done()
+			s.wg.Done()
 			return
 		default:
-			sendIdentify(logger)
+			s.sendIdentify(logger)
 			<-identifyTicker.C
 		}
 	}
 }
 
-func sendIdentify(logger *log.FieldedLogger) {
-	err := globalHQ.client.Identify(&gocrawlhq.IdentifyMessage{
+func (s *HQ) sendIdentify(logger *log.FieldedLogger) {
+	err := s.client.Identify(&gocrawlhq.IdentifyMessage{
 		Project:   config.Get().HQProject,
 		Job:       config.Get().Job,
 		IP:        utils.GetOutboundIP().String(),
@@ -44,12 +44,12 @@ func sendIdentify(logger *log.FieldedLogger) {
 	})
 	if err != nil {
 		logger.Error("error sending identify payload to Crawl HQ, trying to reconnect", "err", err.Error())
-		reconnectWebsocket(logger)
+		s.reconnectWebsocket(logger)
 	}
 }
 
-func reconnectWebsocket(logger *log.FieldedLogger) {
-	err := globalHQ.client.InitWebsocketConn()
+func (s *HQ) reconnectWebsocket(logger *log.FieldedLogger) {
+	err := s.client.InitWebsocketConn()
 	if err != nil {
 		logger.Error("error initializing websocket connection to Crawl HQ", "err", err.Error())
 	}

--- a/internal/pkg/source/source.go
+++ b/internal/pkg/source/source.go
@@ -8,7 +8,7 @@ type Source interface {
 	// Start initializes the source with the given input and output channels.
 	Start(finishChan, produceChan chan *models.Item) error
 	// Stop stops the source.
-	Stop() error
+	Stop()
 	// Name returns the name of the source.
 	Name() string
 }

--- a/internal/pkg/source/source.go
+++ b/internal/pkg/source/source.go
@@ -1,1 +1,14 @@
+// Package source defines the interface for a data source that can produce items to crawl and accept items that have been crawled.
 package source
+
+import "github.com/internetarchive/Zeno/pkg/models"
+
+// Source is an interface for a data source that can produce items to crawl and accept items that have been crawled.
+type Source interface {
+	// Start initializes the source with the given input and output channels.
+	Start(finishChan, produceChan chan *models.Item) error
+	// Stop stops the source.
+	Stop() error
+	// Name returns the name of the source.
+	Name() string
+}


### PR DESCRIPTION
Most is said in the title.
What has been done :
- got rid of `source/hq` and `source/lq` global pointers
- `source/hq` and `source/lq` functions now work as methods and references are held if needed
- `preprocessor` now has a function to set a seencheck function, it is set at the `controler` and retains the same properties as before