### PR TITLE
Simplify WARC writer stats

### DIFF
--- a/internal/pkg/archiver/warc.go
+++ b/internal/pkg/archiver/warc.go
@@ -109,80 +109,40 @@ func GetClients() (clients []*warc.CustomHTTPClient) {
 	return clients
 }
 
+type WARCStats struct {
+	WARCWritingQueueSize         int64
+	WARCTotalBytesArchived       int64
+	CDXDedupeTotalBytes          int64
+	DoppelgangerDedupeTotalBytes int64
+	LocalDedupeTotalBytes        int64
+	CDXDedupeTotal               int64
+	DoppelgangerDedupeTotal      int64
+	LocalDedupeTotal             int64
+}
+
+func GetStats() WARCStats {
+	var stats WARCStats
+
+	for _, c := range []*warc.CustomHTTPClient{globalArchiver.Client, globalArchiver.ClientWithProxy} {
+		if c != nil {
+			stats.WARCWritingQueueSize += int64(c.WaitGroup.Size())
+			stats.WARCTotalBytesArchived += c.DataTotal.Load()
+			stats.CDXDedupeTotalBytes += c.CDXDedupeTotalBytes.Load()
+			stats.DoppelgangerDedupeTotalBytes += c.DoppelgangerDedupeTotalBytes.Load()
+			stats.LocalDedupeTotalBytes += c.LocalDedupeTotalBytes.Load()
+			stats.CDXDedupeTotal += c.CDXDedupeTotal.Load()
+			stats.DoppelgangerDedupeTotal += c.DoppelgangerDedupeTotal.Load()
+			stats.LocalDedupeTotal += c.LocalDedupeTotal.Load()
+		}
+	}
+	return stats
+}
+
+// This function is used in multiple places so it can't be replaced by GetStats()
 func GetWARCWritingQueueSize() (total int) {
 	for _, c := range []*warc.CustomHTTPClient{globalArchiver.Client, globalArchiver.ClientWithProxy} {
 		if c != nil {
 			total += c.WaitGroup.Size()
-		}
-	}
-
-	return total
-}
-
-func GetWARCTotalBytesArchived() (total int64) {
-	for _, c := range []*warc.CustomHTTPClient{globalArchiver.Client, globalArchiver.ClientWithProxy} {
-		if c != nil {
-			total += c.DataTotal.Load()
-		}
-	}
-
-	return total
-}
-
-func GetWARCCDXDedupeTotalBytes() (total int64) {
-	for _, c := range []*warc.CustomHTTPClient{globalArchiver.Client, globalArchiver.ClientWithProxy} {
-		if c != nil {
-			total += c.CDXDedupeTotalBytes.Load()
-		}
-	}
-
-	return total
-}
-
-func GetWARCDoppelgangerDedupeTotalBytes() (total int64) {
-	for _, c := range []*warc.CustomHTTPClient{globalArchiver.Client, globalArchiver.ClientWithProxy} {
-		if c != nil {
-			total += c.DoppelgangerDedupeTotalBytes.Load()
-		}
-	}
-
-	return total
-}
-
-func GetWARCLocalDedupeTotalBytes() (total int64) {
-	for _, c := range []*warc.CustomHTTPClient{globalArchiver.Client, globalArchiver.ClientWithProxy} {
-		if c != nil {
-			total += c.LocalDedupeTotalBytes.Load()
-		}
-	}
-
-	return total
-}
-
-func GetWARCCDXDedupeTotal() (total int64) {
-	for _, c := range []*warc.CustomHTTPClient{globalArchiver.Client, globalArchiver.ClientWithProxy} {
-		if c != nil {
-			total += c.CDXDedupeTotal.Load()
-		}
-	}
-
-	return total
-}
-
-func GetWARCDoppelgangerDedupeTotal() (total int64) {
-	for _, c := range []*warc.CustomHTTPClient{globalArchiver.Client, globalArchiver.ClientWithProxy} {
-		if c != nil {
-			total += c.DoppelgangerDedupeTotal.Load()
-		}
-	}
-
-	return total
-}
-
-func GetWARCLocalDedupeTotal() (total int64) {
-	for _, c := range []*warc.CustomHTTPClient{globalArchiver.Client, globalArchiver.ClientWithProxy} {
-		if c != nil {
-			total += c.LocalDedupeTotal.Load()
 		}
 	}
 

--- a/internal/pkg/controler/watchers/warc.go
+++ b/internal/pkg/controler/watchers/warc.go
@@ -93,18 +93,16 @@ func StartWatchWARCWritingQueue(pauseCheckInterval time.Duration, pauseTimeout t
 			case <-wwqCtx.Done():
 				return
 			case <-statsTicker.C:
-				queueSize := archiver.GetWARCWritingQueueSize()
-
-				stats.WarcWritingQueueSizeSet(int64(queueSize))
-
+				s := archiver.GetStats()
+				stats.WarcWritingQueueSizeSet(s.WARCWritingQueueSize)
 				// Update dedup WARC metrics
-				stats.WARCDataTotalBytesSet(archiver.GetWARCTotalBytesArchived())
-				stats.WARCCDXDedupeTotalBytesSet(archiver.GetWARCCDXDedupeTotalBytes())
-				stats.WARCDoppelgangerDedupeTotalBytesSet(archiver.GetWARCDoppelgangerDedupeTotalBytes())
-				stats.WARCLocalDedupeTotalBytesSet(archiver.GetWARCLocalDedupeTotalBytes())
-				stats.WARCCDXDedupeTotalSet(archiver.GetWARCCDXDedupeTotal())
-				stats.WARCDoppelgangerDedupeTotalSet(archiver.GetWARCDoppelgangerDedupeTotal())
-				stats.WARCLocalDedupeTotalSet(archiver.GetWARCLocalDedupeTotal())
+				stats.WARCDataTotalBytesSet(s.WARCTotalBytesArchived)
+				stats.WARCCDXDedupeTotalBytesSet(s.CDXDedupeTotalBytes)
+				stats.WARCDoppelgangerDedupeTotalBytesSet(s.DoppelgangerDedupeTotalBytes)
+				stats.WARCLocalDedupeTotalBytesSet(s.LocalDedupeTotalBytes)
+				stats.WARCCDXDedupeTotalSet(s.CDXDedupeTotal)
+				stats.WARCDoppelgangerDedupeTotalSet(s.DoppelgangerDedupeTotal)
+				stats.WARCLocalDedupeTotalSet(s.LocalDedupeTotal)
 			}
 		}
 	}()


### PR DESCRIPTION
`internal/pkg/archiver/warc` had 8 functions to get 8 different stats. Each function iterated `[]*warc.CustomHTTPClient{globalArchiver.Client, globalArchiver.ClientWithProxy}` to get a stat.

We use all these functions just in one place except from one.

We can have a single `GetStats` function that returns a `WARCStats` struct with 8 integers. This, way, we'll do just one iteration. Also, now it is easy to extend with more stats.