### PR TITLE
Unit test for extractAssets

### DIFF
--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -208,6 +208,11 @@ func Get() *Config {
 	return config
 }
 
+// Useful for testing
+func Set(cfg *Config) {
+    config = cfg
+}
+
 func GenerateCrawlConfig() error {
 	// If the job name isn't specified, we generate a random name
 	if config.Job == "" {

--- a/internal/pkg/postprocessor/assets.go
+++ b/internal/pkg/postprocessor/assets.go
@@ -11,13 +11,13 @@ import (
 	"github.com/internetarchive/Zeno/pkg/models"
 )
 
-// extractAssets extracts assets from the item's body and returns them.
+// ExtractAssets extracts assets from the item's body and returns them.
 // It also potentially returns outlinks if the body contains URLs that are not assets.
-func extractAssets(item *models.Item) (assets, outlinks []*models.URL, err error) {
+func ExtractAssets(item *models.Item) (assets, outlinks []*models.URL, err error) {
 	var (
 		contentType = item.GetURL().GetResponse().Header.Get("Content-Type")
 		logger      = log.NewFieldedLogger(&log.Fields{
-			"component": "postprocessor.extractAssets",
+			"component": "postprocessor.ExtractAssets",
 		})
 	)
 

--- a/internal/pkg/postprocessor/assets_test.go
+++ b/internal/pkg/postprocessor/assets_test.go
@@ -1,0 +1,60 @@
+package postprocessor
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/internetarchive/Zeno/internal/pkg/config"
+	"github.com/internetarchive/Zeno/pkg/models"
+	"github.com/internetarchive/gowarc/pkg/spooledtempfile"
+)
+
+func TestExtractAssets_HTML(t *testing.T) {
+	config.Set(&config.Config{})
+	config.Get().DisableHTMLTag = []string{} // initialize as empty slice
+
+	// Create a mock response with a minimal HTML body
+	html := `<html><head><link href="style.css"></head><body><img src="img.png"></body></html>`
+	resp := &http.Response{
+		Header:     make(http.Header),
+		Body:       io.NopCloser(bytes.NewBufferString(html)),
+		StatusCode: 200,
+	}
+	resp.Header.Set("Content-Type", "text/html")
+
+	newURL, err := models.NewURL("http://example.com")
+	if err != nil {
+		panic(err)
+	}
+	newURL.SetResponse(resp)
+
+	spooledTempFile := spooledtempfile.NewSpooledTempFile("test", os.TempDir(), 2048, false, -1)
+	spooledTempFile.Write([]byte(html))
+
+	newURL.SetBody(spooledTempFile)
+	newURL.Parse()
+	item := models.NewItem(&newURL, "")
+
+	// Run the extractAssets function
+	assets, outlinks, err := ExtractAssets(item)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	// Basic assertions
+	if len(assets) != 2 {
+		t.Errorf("expected assets, got %d", len(assets))
+	}
+	if assets[0].Raw != "http://example.com/img.png" {
+		t.Errorf("asset extraction failed for http://example.com/img.png")
+
+	}
+	if assets[1].Raw != "http://example.com/style.css" {
+		t.Errorf("asset extraction failed for http://example.com/style.css")
+	}
+	if len(outlinks) != 0 {
+		t.Errorf("expected no outlinks, got %d", len(outlinks))
+	}
+}

--- a/internal/pkg/postprocessor/item.go
+++ b/internal/pkg/postprocessor/item.go
@@ -99,7 +99,7 @@ func postprocessItem(item *models.Item) []*models.Item {
 			var assets []*models.URL
 			var err error
 
-			assets, outlinksFromAssets, err = extractAssets(item)
+			assets, outlinksFromAssets, err = ExtractAssets(item)
 			if err != nil {
 				logger.Error("unable to extract assets", "err", err.Error(), "item_id", item.GetShortID())
 			} else {


### PR DESCRIPTION
Rename `extractAssets` to `ExtractAssets`.

Make unit test.

Make utility function `config.Set()` to be able to mock config in unit test.