### PR TITLE
Refactor request preprocessors

### DIFF
--- a/internal/pkg/preprocessor/preprocessor.go
+++ b/internal/pkg/preprocessor/preprocessor.go
@@ -20,10 +20,7 @@ import (
 	"github.com/internetarchive/Zeno/internal/pkg/controler/pause"
 	"github.com/internetarchive/Zeno/internal/pkg/log"
 	"github.com/internetarchive/Zeno/internal/pkg/log/dumper"
-	"github.com/internetarchive/Zeno/internal/pkg/preprocessor/sitespecific/reddit"
-	"github.com/internetarchive/Zeno/internal/pkg/preprocessor/sitespecific/npr"
-	"github.com/internetarchive/Zeno/internal/pkg/preprocessor/sitespecific/tiktok"
-	"github.com/internetarchive/Zeno/internal/pkg/preprocessor/sitespecific/truthsocial"
+	"github.com/internetarchive/Zeno/internal/pkg/preprocessor/sitespecific"
 	"github.com/internetarchive/Zeno/internal/pkg/stats"
 	"github.com/internetarchive/Zeno/internal/pkg/utils"
 	"github.com/internetarchive/Zeno/pkg/models"
@@ -293,20 +290,7 @@ func preprocess(workerID string, seed *models.Item) {
 		// Apply configured User-Agent
 		req.Header.Set("User-Agent", config.Get().UserAgent)
 
-		switch {
-		case tiktok.IsTikTokURL(items[i].GetURL()):
-			tiktok.AddHeaders(req)
-		case npr.IsNPRURL(items[i].GetURL()):
-			npr.AddHeaders(req)
-		case reddit.IsRedditURL(items[i].GetURL()):
-			reddit.AddCookies(req)
-		case truthsocial.IsStatusAPIURL(items[i].GetURL()) ||
-			truthsocial.IsVideoAPIURL(items[i].GetURL()) ||
-			truthsocial.IsLookupURL(items[i].GetURL()):
-			truthsocial.AddStatusAPIHeaders(req)
-		case truthsocial.IsAccountsAPIURL(items[i].GetURL()):
-			truthsocial.AddAccountsAPIHeaders(req)
-		}
+		sitespecific.RunPreprocessors(items[i].GetURL(), req)
 
 		items[i].GetURL().SetRequest(req)
 		items[i].SetStatus(models.ItemPreProcessed)

--- a/internal/pkg/preprocessor/sitespecific/npr/npr.go
+++ b/internal/pkg/preprocessor/sitespecific/npr/npr.go
@@ -7,11 +7,13 @@ import (
 	"github.com/internetarchive/Zeno/pkg/models"
 )
 
-func IsNPRURL(URL *models.URL) bool {
+type NPRPreprocessor struct{}
+
+func (NPRPreprocessor) Match(URL *models.URL) bool {
 	return strings.Contains(URL.String(), "npr.org/")
 }
 
-func AddHeaders(req *http.Request) {
+func (NPRPreprocessor) Apply(req *http.Request) {
 	req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
 	req.Header.Set("Accept-Language", "fr,fr-FR;q=0.8,en-US;q=0.5,en;q=0.3")
 	req.Header.Set("Referer", "https://www.npr.org/")

--- a/internal/pkg/preprocessor/sitespecific/reddit/reddit.go
+++ b/internal/pkg/preprocessor/sitespecific/reddit/reddit.go
@@ -7,11 +7,13 @@ import (
 	"github.com/internetarchive/Zeno/pkg/models"
 )
 
-func IsRedditURL(URL *models.URL) bool {
+type RedditPreprocessor struct{}
+
+func (RedditPreprocessor) Match(URL *models.URL) bool {
 	return strings.Contains(URL.String(), "reddit.com")
 }
 
-func AddCookies(req *http.Request) {
+func (RedditPreprocessor) Apply(req *http.Request) {
 	newCookies := []http.Cookie{
 		{
 			Name:   "eu_cookie_v2",

--- a/internal/pkg/preprocessor/sitespecific/sitespecific.go
+++ b/internal/pkg/preprocessor/sitespecific/sitespecific.go
@@ -1,0 +1,34 @@
+package sitespecific
+
+import (
+	"net/http"
+
+	"github.com/internetarchive/Zeno/internal/pkg/preprocessor/sitespecific/npr"
+	"github.com/internetarchive/Zeno/internal/pkg/preprocessor/sitespecific/reddit"
+	"github.com/internetarchive/Zeno/internal/pkg/preprocessor/sitespecific/tiktok"
+	"github.com/internetarchive/Zeno/internal/pkg/preprocessor/sitespecific/truthsocial"
+	"github.com/internetarchive/Zeno/pkg/models"
+)
+
+type Preprocessor interface {
+	Match(*models.URL) bool
+	Apply(*http.Request)
+}
+
+var preprocessors = []Preprocessor{
+	npr.NPRPreprocessor{},
+	reddit.RedditPreprocessor{},
+	tiktok.TikTokPreprocessor{},
+	truthsocial.TruthsocialStatusPreprocessor{},
+	truthsocial.TruthsocialStatusPreprocessor{},
+}
+
+// Apply the first matching preprocessor.
+func RunPreprocessors(URL *models.URL, req *http.Request) {
+	for _, p := range preprocessors {
+		if p.Match(URL) {
+			p.Apply(req)
+			break
+		}
+	}
+}

--- a/internal/pkg/preprocessor/sitespecific/sitespecific.go
+++ b/internal/pkg/preprocessor/sitespecific/sitespecific.go
@@ -20,7 +20,7 @@ var preprocessors = []Preprocessor{
 	reddit.RedditPreprocessor{},
 	tiktok.TikTokPreprocessor{},
 	truthsocial.TruthsocialStatusPreprocessor{},
-	truthsocial.TruthsocialStatusPreprocessor{},
+	truthsocial.TruthsocialAccountsPreprocessor{},
 }
 
 // Apply the first matching preprocessor.

--- a/internal/pkg/preprocessor/sitespecific/sitespecific_test.go
+++ b/internal/pkg/preprocessor/sitespecific/sitespecific_test.go
@@ -1,0 +1,42 @@
+package sitespecific
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/internetarchive/Zeno/pkg/models"
+)
+
+func TestPreprocessor(t *testing.T) {
+	targetUrl := "https://www.npr.org/2025/07/16/nx-s1-5468967/npr-pbs-cuts-senate-recission"
+	parsedURL, err := models.NewURL(targetUrl)
+	if err != nil {
+		t.Fatalf("Failed to parsed URL")
+	}
+	req, err := http.NewRequest("GET", targetUrl, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	RunPreprocessors(&parsedURL, req)
+
+	// Check if npr preprocessor added HTTP request headers.
+	if req.Header.Get("Referer") != "https://www.npr.org/" {
+		t.Errorf("HTTP request header wasn't updated %v", req.Header.Get("Referer"))
+	}
+
+	targetUrl2 := "https://www.tiktok.com/@otaldosamu2001/video/7291474492210056454?q=lixnu&t=1752663113132"
+	parsedURL2, err2 := models.NewURL(targetUrl2)
+	if err2 != nil {
+		t.Fatalf("Failed to parsed URL")
+	}
+	req2, err2 := http.NewRequest("GET", targetUrl, nil)
+	if err2 != nil {
+		t.Fatal(err)
+	}
+	RunPreprocessors(&parsedURL2, req2)
+
+	// Check if tiktok preprocessor added HTTP request headers.
+	if req2.Header.Get("Authority") != "www.tiktok.com" {
+		t.Errorf("HTTP request header wasn't updated %v", req2.Header.Get("Authority"))
+	}
+}

--- a/internal/pkg/preprocessor/sitespecific/tiktok/tiktok.go
+++ b/internal/pkg/preprocessor/sitespecific/tiktok/tiktok.go
@@ -7,11 +7,13 @@ import (
 	"github.com/internetarchive/Zeno/pkg/models"
 )
 
-func IsTikTokURL(URL *models.URL) bool {
+type TikTokPreprocessor struct{}
+
+func (TikTokPreprocessor) Match(URL *models.URL) bool {
 	return strings.Contains(URL.String(), "tiktok.com/")
 }
 
-func AddHeaders(req *http.Request) {
+func (TikTokPreprocessor) Apply(req *http.Request) {
 	req.Header.Set("Authority", "www.tiktok.com")
 	req.Header.Set("Sec-Ch-Ua", "\" Not A;Brand\";v=\"99\", \"Chromium\";v=\"99\", \"Microsoft Edge\";v=\"99\"")
 	req.Header.Set("Sec-Ch-Ua-Mobile", "?0")

--- a/internal/pkg/preprocessor/sitespecific/truthsocial/truthsocial.go
+++ b/internal/pkg/preprocessor/sitespecific/truthsocial/truthsocial.go
@@ -7,6 +7,8 @@ import (
 	"github.com/internetarchive/Zeno/pkg/models"
 )
 
+type TruthsocialStatusPreprocessor struct{}
+
 var (
 	APIStatusRegex   = regexp.MustCompile(`^https?:\/\/truthsocial\.com\/api\/v1\/statuses\/(\d+)`)
 	APIVideoRegex    = regexp.MustCompile(`^https?:\/\/truthsocial\.com\/api\/v1\/truth\/videos\/[a-zA-Z0-9]+$`)
@@ -26,23 +28,11 @@ func IsStatusAPIURL(URL *models.URL) bool {
 	return APIStatusRegex.MatchString(URL.String())
 }
 
-func IsAccountsAPIURL(URL *models.URL) bool {
-	return APIAccountsRegex.MatchString(URL.String())
+func (TruthsocialStatusPreprocessor) Match(URL *models.URL) bool {
+	return IsVideoAPIURL(URL) || IsLookupURL(URL) || IsStatusAPIURL(URL)
 }
 
-func AddAccountsAPIHeaders(req *http.Request) {
-	req.Header.Set("User-Agent", "Mozilla/5.0 (X11; Linux x86_64; rv:134.0) Gecko/20100101 Firefox/134.0")
-	req.Header.Set("Accept", "application/json, text/plain, */*")
-	req.Header.Set("Accept-Language", "en-US;q=0.5,en;q=0.3")
-	req.Header.Set("Accept-Encoding", "gzip, deflate, br, zstd")
-	req.Header.Set("Sec-Fetch-Dest", "empty")
-	req.Header.Set("Sec-Fetch-Mode", "cors")
-	req.Header.Set("Sec-Fetch-Site", "same-origin")
-	req.Header.Set("Connection", "keep-alive")
-	req.Header.Set("TE", "trailers")
-}
-
-func AddStatusAPIHeaders(req *http.Request) {
+func (TruthsocialStatusPreprocessor) Apply(req *http.Request) {
 	req.Header.Set("User-Agent", "Mozilla/5.0 (X11; Linux x86_64; rv:134.0) Gecko/20100101 Firefox/134.0")
 	req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
 	req.Header.Set("Accept-Language", "en-US;q=0.5,en;q=0.3")
@@ -53,4 +43,22 @@ func AddStatusAPIHeaders(req *http.Request) {
 	req.Header.Set("Sec-Fetch-Site", "none")
 	req.Header.Set("Sec-Fetch-User", "?1")
 	req.Header.Set("Connection", "keep-alive")
+}
+
+type TruthsocialAccountsPreprocessor struct{}
+
+func (TruthsocialAccountsPreprocessor) Match(URL *models.URL) bool {
+	return APIAccountsRegex.MatchString(URL.String())
+}
+
+func (TruthsocialAccountsPreprocessor) Apply(req *http.Request) {
+	req.Header.Set("User-Agent", "Mozilla/5.0 (X11; Linux x86_64; rv:134.0) Gecko/20100101 Firefox/134.0")
+	req.Header.Set("Accept", "application/json, text/plain, */*")
+	req.Header.Set("Accept-Language", "en-US;q=0.5,en;q=0.3")
+	req.Header.Set("Accept-Encoding", "gzip, deflate, br, zstd")
+	req.Header.Set("Sec-Fetch-Dest", "empty")
+	req.Header.Set("Sec-Fetch-Mode", "cors")
+	req.Header.Set("Sec-Fetch-Site", "same-origin")
+	req.Header.Set("Connection", "keep-alive")
+	req.Header.Set("TE", "trailers")
 }


### PR DESCRIPTION
Use a common Go interface. All preprocessors must implement `Match` and `Apply` methods. Rename the older arbitrary method names and use the interface.

Simplify calling sitespecific preprocessors to just `sitespecific.RunPreprocessors`.

Now, it is much simpler to define a new site specific preprocessor.

Add unit tests.