### PR TITLE
Refactor HTMLOutlinks to use models.URL instead of models.Item

### DIFF
--- a/internal/pkg/postprocessor/extractor/base.go
+++ b/internal/pkg/postprocessor/extractor/base.go
@@ -15,11 +15,11 @@ var basetagLogger = log.NewFieldedLogger(&log.Fields{
 
 // extract document <base> tag and set the base URL for item if it's valid
 // It resets item.base to nil if the base href does not exist or is invalid.
-func extractBaseTag(item *models.Item, doc *goquery.Document) {
+func extractBaseTag(URL *models.URL, doc *goquery.Document) {
 	// spec ref: https://html.spec.whatwg.org/multipage/semantics.html#the-base-element
 	base, exists := doc.Find("base").First().Attr("href")
 	if !exists {
-		item.SetBase(nil)
+		URL.SetBase(nil)
 		return
 	}
 
@@ -34,7 +34,7 @@ func extractBaseTag(item *models.Item, doc *goquery.Document) {
 	baseURL, err := url.Parse(base)
 	if err != nil {
 		basetagLogger.Error("unable to parse base url", "error", err, "base", base)
-		item.SetBase(nil) // Reset the base URL to nil on failure
+		URL.SetBase(nil) // Reset the base URL to nil on failure
 		return
 	}
 
@@ -42,12 +42,12 @@ func extractBaseTag(item *models.Item, doc *goquery.Document) {
 	// We also reject "vbscript" just for the CodeQL scan happy. :)
 	if baseURL.Scheme == "data" || baseURL.Scheme == "javascript" || baseURL.Scheme == "vbscript" {
 		basetagLogger.Error("the base url has the bad scheme", "base", base, "scheme", baseURL.Scheme)
-		item.SetBase(nil)
+		URL.SetBase(nil)
 		return
 	}
 
-	fallbackBaseURL := item.GetURL().GetParsed()
+	fallbackBaseURL := URL.GetParsed()
 	newResolvedBaseURL := fallbackBaseURL.ResolveReference(baseURL)
 
-	item.SetBase(newResolvedBaseURL)
+	URL.SetBase(newResolvedBaseURL)
 }

--- a/internal/pkg/postprocessor/extractor/base_test.go
+++ b/internal/pkg/postprocessor/extractor/base_test.go
@@ -21,13 +21,13 @@ func newDocumentWithBaseTag(base string) *goquery.Document {
 func TestExtractBaseTag(t *testing.T) {
 	doc := newDocumentWithBaseTag("http://example.com/something/")
 
-	item := models.NewItem(&models.URL{
+	URL := &models.URL{
 		Raw: "https://example.com/something/page.html",
-	}, "")
+	}
 
-	extractBaseTag(item, doc)
+	extractBaseTag(URL, doc)
 
-	if item.GetBase().String() != "http://example.com/something/" {
+	if URL.GetBase().String() != "http://example.com/something/" {
 		t.Errorf("Cannot find html doc base.href")
 	}
 }

--- a/internal/pkg/postprocessor/extractor/html.go
+++ b/internal/pkg/postprocessor/extractor/html.go
@@ -22,8 +22,8 @@ func IsHTML(URL *models.URL) bool {
 	return URL.GetMIMEType() != nil && strings.Contains(URL.GetMIMEType().String(), "html")
 }
 
-func HTMLOutlinks(item *models.Item) (outlinks []*models.URL, err error) {
-	defer item.GetURL().RewindBody()
+func HTMLOutlinks(URL *models.URL) (outlinks []*models.URL, err error) {
+	defer URL.RewindBody()
 
 	logger := log.NewFieldedLogger(&log.Fields{
 		"component": "postprocessor.extractor.HTMLOutlinks",
@@ -32,13 +32,13 @@ func HTMLOutlinks(item *models.Item) (outlinks []*models.URL, err error) {
 	var rawOutlinks []string
 
 	// Retrieve (potentially creates it) the document from the body
-	document, err := item.GetURL().GetDocument()
+	document, err := URL.GetDocument()
 	if err != nil {
 		return nil, err
 	}
 
 	// Extract the base tag if it exists
-	extractBaseTag(item, document)
+	extractBaseTag(URL, document)
 
 	// Match <a> tags with href, data-href, data-src, data-srcset, data-lazy-src, data-srcset, src, srcset
 	// Extract potential URLs from <a> tags using common attributes
@@ -93,9 +93,9 @@ func HTMLOutlinks(item *models.Item) (outlinks []*models.URL, err error) {
 	}
 
 	for _, rawOutlink := range rawOutlinks {
-		resolvedURL, err := resolveURL(rawOutlink, item)
+		resolvedURL, err := resolveURL(rawOutlink, URL)
 		if err != nil {
-			logger.Debug("unable to resolve URL", "error", err, "url", item.GetURL(), "item", item.GetShortID())
+			logger.Debug("unable to resolve URL", "error", err, "url", URL)
 		} else if resolvedURL != "" {
 			outlinks = append(outlinks, &models.URL{
 				Raw: resolvedURL,
@@ -104,8 +104,8 @@ func HTMLOutlinks(item *models.Item) (outlinks []*models.URL, err error) {
 		}
 
 		// Discard URLs that are the same as the base URL or the current URL
-		if (item.GetBase() != nil && rawOutlink == item.GetBase().String()) || rawOutlink == item.GetURL().String() {
-			logger.Debug("discarding outlink because it is the same as the base URL or current URL", "url", rawOutlink, "item", item.GetShortID())
+		if (URL.GetBase() != nil && rawOutlink == URL.GetBase().String()) || rawOutlink == URL.String() {
+			logger.Debug("discarding outlink because it is the same as the base URL or current URL", "url", rawOutlink)
 			continue
 		}
 
@@ -131,7 +131,7 @@ func HTMLAssets(item *models.Item) (assets []*models.URL, err error) {
 	}
 
 	// Extract the base tag if it exists
-	extractBaseTag(item, document)
+	extractBaseTag(item.GetURL(), document)
 
 	// Get assets from JSON payloads in data-item values
 	// Check all elements style attributes for background-image & also data-preview
@@ -409,11 +409,11 @@ func HTMLAssets(item *models.Item) (assets []*models.URL, err error) {
 	}
 
 	for _, rawAsset := range rawAssets {
-		resolvedURL, err := resolveURL(rawAsset, item)
+		resolvedURL, err := resolveURL(rawAsset, item.GetURL())
 		if err != nil {
 			var baseURL string
-			if item.GetBase() != nil {
-				baseURL = item.GetBase().String()
+			if item.GetURL().GetBase() != nil {
+				baseURL = item.GetURL().GetBase().String()
 			}
 			logger.Debug("unable to resolve URL", "error", err, "item_url", item.GetURL(), "base_url", baseURL, "target", rawAsset, "item", item.GetShortID())
 		} else if resolvedURL != "" {

--- a/internal/pkg/postprocessor/extractor/html_test.go
+++ b/internal/pkg/postprocessor/extractor/html_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/internetarchive/Zeno/pkg/models"
 )
 
-func setupItem(html string) *models.Item {
+func setupURL(html string) *models.URL {
 	resp := &http.Response{
 		Body:   io.NopCloser(bytes.NewBufferString(html)),
 		Header: make(http.Header),
@@ -27,7 +27,12 @@ func setupItem(html string) *models.Item {
 	if err := archiver.ProcessBody(&newURL, false, false, 0, os.TempDir()); err != nil {
 		panic(err)
 	}
-	return models.NewItem(&newURL, "")
+	return &newURL
+}
+
+func setupItem(html string) *models.Item {
+	newURL := setupURL(html)
+	return models.NewItem(newURL, "")
 }
 
 func TestHTMLOutlinks(t *testing.T) {
@@ -48,9 +53,9 @@ func TestHTMLOutlinks(t *testing.T) {
 			</map>
 		</body>
 	</html>`
-	item := setupItem(html)
+	URL := setupURL(html)
 
-	outlinks, err := HTMLOutlinks(item)
+	outlinks, err := HTMLOutlinks(URL)
 	if err != nil {
 		t.Errorf("Error extracting HTML outlinks %s", err)
 	}
@@ -190,8 +195,8 @@ func TestUpperCase(t *testing.T) {
 	   <A HREF="https://a.com/a.html">text</A>
 	   </BODY>
     </HTML>`
-	item := setupItem(html)
-	outlinks, err := HTMLOutlinks(item)
+	URL := setupURL(html)
+	outlinks, err := HTMLOutlinks(URL)
 	if err != nil {
 		t.Errorf("Error extracting HTML outlinks %s", err)
 	}

--- a/internal/pkg/postprocessor/extractor/resolve.go
+++ b/internal/pkg/postprocessor/extractor/resolve.go
@@ -10,19 +10,19 @@ import (
 // resolveURL takes a URL string to resolve, a parent URL, and a base.
 // If base is empty, it uses the parent URL as the base.
 // It returns an absolute URL as a string.
-func resolveURL(URL string, item *models.Item) (absolute string, err error) {
+func resolveURL(rawURL string, URL *models.URL) (absolute string, err error) {
 	// Determine the base URL.
 	var baseURL *url.URL
-	if item.GetBase() == nil { // If no base is provided, use the parent URL.
-		baseURL = item.GetURL().GetParsed()
+	if URL.GetBase() == nil { // If no base is provided, use the parent URL.
+		baseURL = URL.GetParsed()
 	} else {
-		baseURL = item.GetBase()
+		baseURL = URL.GetBase()
 	}
 
 	// Parse the URL to resolve.
-	link, err := url.Parse(URL)
+	link, err := url.Parse(rawURL)
 	if err != nil {
-		return "", fmt.Errorf("invalid URL %q: %w", URL, err)
+		return "", fmt.Errorf("invalid URL %q: %w", rawURL, err)
 	}
 
 	// If the link is already absolute, return it.

--- a/internal/pkg/postprocessor/extractor/resolve_test.go
+++ b/internal/pkg/postprocessor/extractor/resolve_test.go
@@ -114,9 +114,9 @@ func TestResolveURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			item := models.NewItemWithID("test", &models.URL{
+			URL := &models.URL{
 				Raw: tt.parentURL,
-			}, "")
+			}
 
 			var doc *goquery.Document
 			if tt.base != "" {
@@ -127,16 +127,16 @@ func TestResolveURL(t *testing.T) {
 				doc, _ = goquery.NewDocumentFromReader(strings.NewReader(`<html></html>`))
 			}
 
-			extractBaseTag(item, doc)
+			extractBaseTag(URL, doc)
 
-			isBaseUnset := item.GetBase() == nil
+			isBaseUnset := URL.GetBase() == nil
 			if tt.wantBaseUnset != isBaseUnset {
 				t.Errorf("resolveURL() isBaseUnset = %v, test_name = %s, wantBaseUnset %v", isBaseUnset, tt.name, tt.wantBaseUnset)
 			}
 
-			preprocessor.NormalizeURL(item.GetURL(), nil)
+			preprocessor.NormalizeURL(URL, nil)
 
-			got, err := resolveURL(tt.URL, item)
+			got, err := resolveURL(tt.URL, URL)
 			if (err != nil) != tt.expectErr {
 				t.Errorf("resolveURL() error = %v, test_name = %s, expectErr %v", err, tt.name, tt.expectErr)
 				return

--- a/internal/pkg/postprocessor/outlinks.go
+++ b/internal/pkg/postprocessor/outlinks.go
@@ -60,7 +60,7 @@ func extractOutlinks(item *models.Item) (outlinks []*models.URL, err error) {
 		// we just want to extract all the URLs from the sitemap
 		outlinks = append(outlinks, assets...)
 	case extractor.IsHTML(item.GetURL()):
-		outlinks, err = extractor.HTMLOutlinks(item)
+		outlinks, err = extractor.HTMLOutlinks(item.GetURL())
 		if err != nil {
 			logger.Error("unable to extract outlinks", "extractor", "HTMLOutlinks", "err", err.Error(), "item", item.GetShortID(), "url", item.GetURL())
 			return outlinks, err

--- a/pkg/models/item.go
+++ b/pkg/models/item.go
@@ -3,7 +3,6 @@ package models
 import (
 	"errors"
 	"fmt"
-	"net/url"
 	"strings"
 	"sync"
 
@@ -19,7 +18,6 @@ type Item struct {
 	seedVia    string       // SeedVia is the source of the seed (shoud not be used for non-seeds)
 	status     ItemState    // Status is the state of the item in the pipeline
 	source     ItemSource   // Source is the source of the item in the pipeline
-	base       *url.URL     // Base is the base URL of the item, extracted from a <base> tag
 	childrenMu sync.RWMutex // Mutex to protect the children slice
 	children   []*Item      // Children is a slice of Item created from this item
 	parent     *Item        // Parent is the parent of the item (will be nil if the item is a seed)
@@ -175,9 +173,6 @@ func (i *Item) GetStatus() ItemState { return i.status }
 // GetSource returns the source of the item
 func (i *Item) GetSource() ItemSource { return i.source }
 
-// GetBase returns the base URL of the item
-func (i *Item) GetBase() *url.URL { return i.base }
-
 // GetMaxDepth returns the maxDepth of the item by traversing the tree
 func (i *Item) GetMaxDepth() int64 {
 	if len(i.GetChildren()) == 0 {
@@ -293,9 +288,6 @@ func (i *Item) SetSource(source ItemSource) error {
 	i.source = source
 	return nil
 }
-
-// SetBase sets the base URL of the item
-func (i *Item) SetBase(base *url.URL) { i.base = base }
 
 // SetError sets the error of the item
 func (i *Item) SetError(err error) { i.err = err }

--- a/pkg/models/url.go
+++ b/pkg/models/url.go
@@ -21,6 +21,7 @@ type URL struct {
 	parsed    *url.URL
 	request   *http.Request
 	response  *http.Response
+    base       *url.URL     // Base is the base URL of the HTML doc, extracted from a <base> tag
 	body      spooledtempfile.ReadSeekCloser
 	document  *goquery.Document
 	mimetype  *mimetype.MIME
@@ -146,6 +147,16 @@ func (u *URL) String() string {
 		u.stringCache = URLToString(u.parsed)
 	})
 	return u.stringCache
+}
+
+// GetBase returns the base URL of the item
+func (u *URL) GetBase() *url.URL {
+	return u.base
+}
+
+ // SetBase sets the base URL of the item
+func (u *URL) SetBase(base *url.URL) {
+	u.base = base
 }
 
 // URLToString exists to apply some custom stuff, in opposition of simply

--- a/pkg/models/url.go
+++ b/pkg/models/url.go
@@ -21,7 +21,7 @@ type URL struct {
 	parsed    *url.URL
 	request   *http.Request
 	response  *http.Response
-    base       *url.URL     // Base is the base URL of the HTML doc, extracted from a <base> tag
+	base      *url.URL // Base is the base URL of the HTML doc, extracted from a <base> tag
 	body      spooledtempfile.ReadSeekCloser
 	document  *goquery.Document
 	mimetype  *mimetype.MIME
@@ -154,7 +154,7 @@ func (u *URL) GetBase() *url.URL {
 	return u.base
 }
 
- // SetBase sets the base URL of the item
+// SetBase sets the base URL of the item
 func (u *URL) SetBase(base *url.URL) {
 	u.base = base
 }


### PR DESCRIPTION
We need all outlink extractors to use the same inputs / outputs for better code organization and correctness.
Without this change, we can't use Go interfaces.

Modify `HTMLOutlinks` extractor to use `models.URL` instead of `models.Item`.

Move the `base` attribute and related `GetBase`, `SetBase` methods from `Item` to `URL`. This also makes sense as the base URL attribute is more related to the `URL` object.

Modify `resolveURL` extractor to use `models.URL` instead of `models.Item`.

Modify `extractBaseTag` extractor to use `models.URL` instead of `models.Item`.