### PR TITLE
Update ExtractAPIPostPermalinks to use models.URL instead of models.Item

### DIFF
--- a/internal/pkg/postprocessor/outlinks.go
+++ b/internal/pkg/postprocessor/outlinks.go
@@ -72,7 +72,7 @@ func extractOutlinks(item *models.Item) (outlinks []*models.URL, err error) {
 			return outlinks, err
 		}
 	case reddit.IsPostAPI(item.GetURL()):
-		outlinks, err = reddit.ExtractAPIPostPermalinks(item)
+		outlinks, err = reddit.ExtractAPIPostPermalinks(item.GetURL())
 		if err != nil {
 			logger.Error("unable to extract outlinks", "extractor", "reddit.ExtractAPIPostPermalinks", "err", err.Error(), "item", item.GetShortID(), "url", item.GetURL())
 			return outlinks, err

--- a/internal/pkg/postprocessor/sitespecific/reddit/api.go
+++ b/internal/pkg/postprocessor/sitespecific/reddit/api.go
@@ -190,12 +190,12 @@ func IsPostAPI(URL *models.URL) bool {
 	return strings.Contains(URL.String(), "reddit.com/api/info.json?id=t3_")
 }
 
-func ExtractAPIPostPermalinks(item *models.Item) (outlinks []*models.URL, err error) {
+func ExtractAPIPostPermalinks(URL *models.URL) (outlinks []*models.URL, err error) {
 	var permalinks []string
 
-	defer item.GetURL().RewindBody()
+	defer URL.RewindBody()
 
-	body, err := io.ReadAll(item.GetURL().GetBody())
+	body, err := io.ReadAll(URL.GetBody())
 	if err != nil {
 		return outlinks, err
 	}
@@ -215,7 +215,7 @@ func ExtractAPIPostPermalinks(item *models.Item) (outlinks []*models.URL, err er
 	for _, rawOutlink := range permalinks {
 		outlinks = append(outlinks, &models.URL{
 			Raw:  rawOutlink,
-			Hops: item.GetURL().GetHops() + 1,
+			Hops: URL.GetHops() + 1,
 		})
 	}
 


### PR DESCRIPTION
We need all outlink extractors to use the same inputs / outputs for better code organization and correctness. Without this change, we can't use Go interfaces.

Modify ExtractAPIPostPermalinks extractor to use models.URL instead of models.Item.

Relevant to https://github.com/internetarchive/Zeno/pull/390