### PR TITLE
Move SetDocument(nil) to Item.Close

### DIFF
--- a/internal/pkg/postprocessor/item.go
+++ b/internal/pkg/postprocessor/item.go
@@ -170,9 +170,6 @@ func postprocessItem(item *models.Item) []*models.Item {
 		}
 	}
 
-	// Make sure the goquery document's memory can be freed
-	item.GetURL().SetDocument(nil)
-
 	if !item.HasChildren() && !item.HasRedirection() && item.GetStatus() != models.ItemFailed {
 		logger.Debug("item has no children, setting as completed", "item_id", item.GetShortID())
 		item.SetStatus(models.ItemCompleted)

--- a/pkg/models/item.go
+++ b/pkg/models/item.go
@@ -430,6 +430,8 @@ func (i *Item) Close() {
             panic(fmt.Sprintf("unable to close body, err: %s, seed id: %s", err.Error(), i.GetShortID()))
         }
         i.url.SetBody(nil)
+        // Make sure the goquery document's memory can be freed
+        i.url.SetDocument(nil)
     }
 }
 


### PR DESCRIPTION
Placing `SetDocument(nil)` in the end of the method doesn't guarantee that it will be always executed. If the method returns early, it is skipped and memory isn't freed.

`Item` has a `Close()` method. Conceptually its better to include memory cleanup in `Item.Close`.

Also, method `postprocessItem` includes `defer item.Close()`.

So, it makes sense to move `SetDocument(nil)` in there.