### PR TITLE
Refactor ExtractAssets

### DIFF
--- a/internal/pkg/postprocessor/assets.go
+++ b/internal/pkg/postprocessor/assets.go
@@ -11,20 +11,23 @@ import (
 	"github.com/internetarchive/Zeno/pkg/models"
 )
 
-// ExtractAssets extracts assets from the item's body and returns them.
+// ExtractAssetsOutlinks extracts assets from the item's body and returns them.
 // It also potentially returns outlinks if the body contains URLs that are not assets.
-func ExtractAssets(item *models.Item) (assets, outlinks []*models.URL, err error) {
-	var (
-		contentType = item.GetURL().GetResponse().Header.Get("Content-Type")
-		logger      = log.NewFieldedLogger(&log.Fields{
-			"component": "postprocessor.ExtractAssets",
-		})
-	)
+func ExtractAssetsOutlinks(item *models.Item) (assets, outlinks []*models.URL, err error) {
+	assets, outlinks, err = Extractors(item)
+	return SanitizeAssetsOutlinks(item, assets, outlinks, err)
+}
 
-	// Extract assets from the body using the appropriate extractor
+// Extract assets and outlinks from the body using the appropriate extractor
+// Order is important, we want to check for more specific things first,
+// as they may trigger more general extractors (e.g. HTML)
+// TODO this should be refactored using interfaces
+func Extractors(item *models.Item) (assets, outlinks []*models.URL, err error) {
+	logger := log.NewFieldedLogger(&log.Fields{
+		"component": "postprocessor.Extractors",
+	})
+
 	switch {
-	// Order is important, we want to check for more specific things first,
-	// as they may trigger more general extractors (e.g. HTML)
 	case ina.IsAPIURL(item.GetURL()):
 		INAAssets, err := ina.ExtractMedias(item.GetURL())
 		if err != nil {
@@ -82,10 +85,18 @@ func ExtractAssets(item *models.Item) (assets, outlinks []*models.URL, err error
 		}
 		extractor.AddAtImportLinksToItemChild(item, atImportLinks)
 	default:
+		contentType := item.GetURL().GetResponse().Header.Get("Content-Type")
 		logger.Debug("no extractor used for page", "content-type", contentType, "mime", item.GetURL().GetMIMEType().String(), "item", item.GetShortID())
 		return assets, outlinks, nil
 	}
 
+	return assets, outlinks, err
+}
+
+func SanitizeAssetsOutlinks(item *models.Item, assets []*models.URL, outlinks []*models.URL, err error) ([]*models.URL, []*models.URL, error) {
+	logger := log.NewFieldedLogger(&log.Fields{
+		"component": "postprocessor.SanitizeAssetsOutlinks",
+	})
 	for i := 0; i < len(assets); {
 		asset := assets[i]
 

--- a/internal/pkg/postprocessor/assets_test.go
+++ b/internal/pkg/postprocessor/assets_test.go
@@ -38,8 +38,7 @@ func TestExtractAssets_HTML(t *testing.T) {
 	newURL.Parse()
 	item := models.NewItem(&newURL, "")
 
-	// Run the extractAssets function
-	assets, outlinks, err := ExtractAssets(item)
+	assets, outlinks, err := ExtractAssetsOutlinks(item)
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}

--- a/internal/pkg/postprocessor/assets_test.go
+++ b/internal/pkg/postprocessor/assets_test.go
@@ -57,3 +57,30 @@ func TestExtractAssets_HTML(t *testing.T) {
 		t.Errorf("expected no outlinks, got %d", len(outlinks))
 	}
 }
+
+func TestSanitizeAssetsOutlinks(t *testing.T) {
+	var err error
+	newURL, _ := models.NewURL("http://example.com")
+	newItem := models.NewItem(&newURL, "")
+
+	a1, _ := models.NewURL("http://a1.com")
+	a2, _ := models.NewURL("mailto:info@archive.org") // must filter out
+	a3, _ := models.NewURL("http://example.com")      // equal to item URL, must filter out
+
+	assets := []*models.URL{&a1, &a2, &a3}
+
+	o1, _ := models.NewURL("http://ol1.com")
+	o2, _ := models.NewURL("javascript:function(){alert('hi')}") // must filter out
+	outlinks := []*models.URL{&o1, &o2}
+	assets, outlinks, err = SanitizeAssetsOutlinks(newItem, assets, outlinks, err)
+
+	if err != nil {
+		t.Errorf("unexpected error  %v", err)
+	}
+	if len(assets) != 1 {
+		t.Errorf("expected 1 filtered asset, got %d", len(assets))
+	}
+	if len(outlinks) != 1 {
+		t.Errorf("expected 1 filtered outlink, got %d", len(outlinks))
+	}
+}

--- a/internal/pkg/postprocessor/item.go
+++ b/internal/pkg/postprocessor/item.go
@@ -99,7 +99,7 @@ func postprocessItem(item *models.Item) []*models.Item {
 			var assets []*models.URL
 			var err error
 
-			assets, outlinksFromAssets, err = ExtractAssets(item)
+			assets, outlinksFromAssets, err = ExtractAssetsOutlinks(item)
 			if err != nil {
 				logger.Error("unable to extract assets", "err", err.Error(), "item_id", item.GetShortID())
 			} else {


### PR DESCRIPTION
Rename `ExtractAssets` to `ExtractAssetsOutlinks` because the function
returns assets and potentially outlinks. The original name was
confusing.

Split `ExtractAssetsOutlinks` into 2 functions: `Extractors` and
`SanitizeAssetsOutlinks`.

The sanitization function now runs for all extractor output, earlier it
didn't run when an error occured. See issue:
https://github.com/internetarchive/Zeno/issues/396

Add unit test for `SanitizeAssetsOutlinks`.