### PR TITLE
Outlink extractor refactoring using interfaces

### DIFF
--- a/internal/pkg/postprocessor/extractor/html.go
+++ b/internal/pkg/postprocessor/extractor/html.go
@@ -22,7 +22,13 @@ func IsHTML(URL *models.URL) bool {
 	return URL.GetMIMEType() != nil && strings.Contains(URL.GetMIMEType().String(), "html")
 }
 
-func HTMLOutlinks(URL *models.URL) (outlinks []*models.URL, err error) {
+type HTMLOutlinkExtractor struct{}
+
+func (HTMLOutlinkExtractor) Match(URL *models.URL) bool {
+	return IsHTML(URL)
+}
+
+func (HTMLOutlinkExtractor) Extract(URL *models.URL) (outlinks []*models.URL, err error) {
 	defer URL.RewindBody()
 
 	logger := log.NewFieldedLogger(&log.Fields{

--- a/internal/pkg/postprocessor/extractor/html_test.go
+++ b/internal/pkg/postprocessor/extractor/html_test.go
@@ -55,7 +55,8 @@ func TestHTMLOutlinks(t *testing.T) {
 	</html>`
 	URL := setupURL(html)
 
-	outlinks, err := HTMLOutlinks(URL)
+	extractor := HTMLOutlinkExtractor{}
+	outlinks, err := extractor.Extract(URL)
 	if err != nil {
 		t.Errorf("Error extracting HTML outlinks %s", err)
 	}
@@ -196,7 +197,8 @@ func TestUpperCase(t *testing.T) {
 	   </BODY>
     </HTML>`
 	URL := setupURL(html)
-	outlinks, err := HTMLOutlinks(URL)
+	extractor := HTMLOutlinkExtractor{}
+	outlinks, err := extractor.Extract(URL)
 	if err != nil {
 		t.Errorf("Error extracting HTML outlinks %s", err)
 	}

--- a/internal/pkg/postprocessor/extractor/object_storage.go
+++ b/internal/pkg/postprocessor/extractor/object_storage.go
@@ -15,15 +15,17 @@ var ObjectStorageServers = func() (s []string) {
 	return s
 }()
 
-// IsObjectStorage checks if the response is from an object storage server
-func IsObjectStorage(URL *models.URL) bool {
+type ObjectStorageOutlinkExtractor struct{}
+
+// Check if the response is from an object storage server
+func (ObjectStorageOutlinkExtractor) Match(URL *models.URL) bool {
 	return utils.StringContainsSliceElements(URL.GetResponse().Header.Get("Server"), ObjectStorageServers) &&
 		URL.GetMIMEType() != nil &&
 		strings.Contains(URL.GetMIMEType().String(), "/xml") // tricky match both application/xml and text/xml
 }
 
 // ObjectStorage decides which helper to call based on the object storage server
-func ObjectStorage(URL *models.URL) ([]*models.URL, error) {
+func (ObjectStorageOutlinkExtractor) Extract(URL *models.URL) ([]*models.URL, error) {
 	defer URL.RewindBody()
 
 	server := URL.GetResponse().Header.Get("Server")

--- a/internal/pkg/postprocessor/extractor/object_storage_azure_test.go
+++ b/internal/pkg/postprocessor/extractor/object_storage_azure_test.go
@@ -38,7 +38,8 @@ func TestAzure(t *testing.T) {
 </EnumerationResults>`
 		URLObj := buildTestObjectStorageURLObj("http://example.com/devstoreaccount1/zeno?restype=container&comp=list&maxresults=1", xmlBody, http.Header{"Server": []string{"Windows-Azure-Blob/1.0"}})
 		outlinks, err := azure(URLObj)
-		outlinks2, err2 := ObjectStorage(URLObj) // indirectly call, for coverage testing
+		extractor := ObjectStorageOutlinkExtractor{}
+		outlinks2, err2 := extractor.Extract(URLObj) // indirectly call, for coverage testing
 		if err != nil || err2 != nil {
 			t.Fatalf("azure() returned unexpected error: %v, err2: %v", err, err2)
 		}

--- a/internal/pkg/postprocessor/extractor/object_storage_s3_test.go
+++ b/internal/pkg/postprocessor/extractor/object_storage_s3_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestS3Compatible(t *testing.T) {
+	extractor := ObjectStorageOutlinkExtractor{}
 	// This subtest shows a scenario of a valid XML with a single object,
 	// and list-type != 2 => "marker" logic should be used.
 	t.Run("Valid XML with single object, no list-type=2 => marker next link", func(t *testing.T) {
@@ -22,7 +23,7 @@ func TestS3Compatible(t *testing.T) {
 
 		URLObj := buildTestObjectStorageURLObj("https://example.com/?someparam=1", xmlBody, http.Header{"Server": []string{"AmazonS3"}})
 		outlinks, err := s3Compatible(URLObj)
-		outlinks2, err2 := ObjectStorage(URLObj) // indirectly call, for coverage testing
+		outlinks2, err2 := extractor.Extract(URLObj) // indirectly call, for coverage testing
 		if err != nil || err2 != nil {
 			t.Fatalf("S3() returned unexpected error: %v, err2: %v", err, err2)
 		}
@@ -54,7 +55,7 @@ func TestS3Compatible(t *testing.T) {
 
 		URLObj := buildTestObjectStorageURLObj("https://example.com/?list-type=2", xmlBody, http.Header{"Server": []string{"AmazonS3"}})
 		outlinks, err := s3Compatible(URLObj)
-		outlinks2, err2 := ObjectStorage(URLObj) // indirectly call, for coverage testing
+		outlinks2, err2 := extractor.Extract(URLObj) // indirectly call, for coverage testing
 		if err != nil || err2 != nil {
 			t.Fatalf("s3Compatible() returned unexpected error: %v, err2: %v", err, err2)
 		}
@@ -77,7 +78,7 @@ func TestS3Compatible(t *testing.T) {
 
 		URLObj := buildTestObjectStorageURLObj("https://example.com/?list-type=2", xmlBody, http.Header{"Server": []string{"AmazonS3"}})
 		outlinks, err := s3Compatible(URLObj)
-		outlinks2, err2 := ObjectStorage(URLObj) // indirectly call, for coverage testing
+		outlinks2, err2 := extractor.Extract(URLObj) // indirectly call, for coverage testing
 		if err == nil || err2 == nil {
 			t.Fatalf("expected error for invalid XML, got none")
 		}

--- a/internal/pkg/postprocessor/extractor/object_storage_test.go
+++ b/internal/pkg/postprocessor/extractor/object_storage_test.go
@@ -32,7 +32,7 @@ func buildTestObjectStorageURLObj(selfURL, xmlBody string, respHeader http.Heade
 }
 
 // TestIsObjectStorage checks the Server header for known OSS Server strings.
-func TestIsObjectStorage(t *testing.T) {
+func TestObjectStorageOutlinkExtractorMatch(t *testing.T) {
 	tests := []struct {
 		name   string
 		server string
@@ -45,6 +45,7 @@ func TestIsObjectStorage(t *testing.T) {
 		{"No match", "Apache", false},
 		{"Partial match", "Amazon", false},
 	}
+	extractor := ObjectStorageOutlinkExtractor{}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -58,9 +59,9 @@ func TestIsObjectStorage(t *testing.T) {
 				},
 			})
 
-			got := IsObjectStorage(URLObj)
+			got := extractor.Match(URLObj)
 			if got != tt.want {
-				t.Errorf("IsObjectStorage(server=%q) = %v, want %v", tt.server, got, tt.want)
+				t.Errorf("ObjectStorageOutlinkExtractor.Match(server=%q) = %v, want %v", tt.server, got, tt.want)
 			}
 		})
 	}
@@ -71,7 +72,8 @@ func TestObjectStorage(t *testing.T) {
 		xmlBody := `<Placeholder>XML</Placeholder>`
 
 		URLObj := buildTestObjectStorageURLObj("https://example.com/", xmlBody, http.Header{"Server": []string{"NotAnOSS"}})
-		_, err := ObjectStorage(URLObj)
+		extractor := ObjectStorageOutlinkExtractor{}
+		_, err := extractor.Extract(URLObj)
 
 		if err == nil {
 			t.Fatalf("expected error for unknown object storage server, got none")

--- a/internal/pkg/postprocessor/extractor/pdf.go
+++ b/internal/pkg/postprocessor/extractor/pdf.go
@@ -13,11 +13,13 @@ func init() {
 	pdfapi.DisableConfigDir()
 }
 
-func IsPDF(URL *models.URL) bool {
+type PDFOutlinkExtractor struct{}
+
+func (PDFOutlinkExtractor) Match(URL *models.URL) bool {
 	return URL.GetMIMEType().Is("application/pdf")
 }
 
-func PDF(URL *models.URL) (outlinks []*models.URL, err error) {
+func (PDFOutlinkExtractor) Extract(URL *models.URL) (outlinks []*models.URL, err error) {
 	defer URL.RewindBody()
 
 	annots, err := pdfapi.Annotations(URL.GetBody(), nil, nil)

--- a/internal/pkg/postprocessor/extractor/pdf_test.go
+++ b/internal/pkg/postprocessor/extractor/pdf_test.go
@@ -21,7 +21,7 @@ var CorruptPDF []byte
 
 func TestPDF(t *testing.T) {
 	resp := &http.Response{
-		Body: io.NopCloser(bytes.NewBuffer(DeveloperPortalPDF)),
+		Body:   io.NopCloser(bytes.NewBuffer(DeveloperPortalPDF)),
 		Header: make(http.Header),
 	}
 	resp.Header.Set("Content-Type", "application/pdf")
@@ -35,7 +35,8 @@ func TestPDF(t *testing.T) {
 	}
 
 	start := time.Now()
-	outlinks, err := PDF(URL)
+	extractor := PDFOutlinkExtractor{}
+	outlinks, err := extractor.Extract(URL)
 	if err != nil {
 		t.Error(err)
 		return
@@ -43,7 +44,7 @@ func TestPDF(t *testing.T) {
 
 	want := 19
 	if len(outlinks) != want {
-		t.Errorf("PDF() got = %v, want %v", len(outlinks), want)
+		t.Errorf("PDFOutlinkExtractor.Extract() got = %v, want %v", len(outlinks), want)
 	}
 	t.Logf("PDF extraction took %v", time.Since(start))
 }
@@ -51,7 +52,7 @@ func TestPDF(t *testing.T) {
 // must fail gracefully with corrupt files.
 func TestCorruptPDF(t *testing.T) {
 	resp := &http.Response{
-		Body: io.NopCloser(bytes.NewBuffer(CorruptPDF)),
+		Body:   io.NopCloser(bytes.NewBuffer(CorruptPDF)),
 		Header: make(http.Header),
 	}
 	resp.Header.Set("Content-Type", "application/pdf")
@@ -64,7 +65,8 @@ func TestCorruptPDF(t *testing.T) {
 		t.Errorf("ProcessBody() error = %v", err)
 	}
 
-	outlinks, err := PDF(URL)
+	extractor := PDFOutlinkExtractor{}
+	outlinks, err := extractor.Extract(URL)
 	if err == nil {
 		t.Error("Corrupt PDF must raise an error")
 	}

--- a/internal/pkg/postprocessor/extractor/xml.go
+++ b/internal/pkg/postprocessor/extractor/xml.go
@@ -159,3 +159,21 @@ func XML(URL *models.URL) (assets, outlinks []*models.URL, err error) {
 
 	return assets, outlinks, nil
 }
+
+type SitemapXMLOutlinkExtractor struct{}
+
+func (SitemapXMLOutlinkExtractor) Match(URL *models.URL) bool {
+	return IsSitemapXML(URL)
+}
+
+func (SitemapXMLOutlinkExtractor) Extract(URL *models.URL) ([]*models.URL, error) {
+	assets, outlinks, err := XML(URL)
+	if err != nil {
+		return outlinks, err
+	}
+
+	// Here we don't care about the difference between assets and outlinks,
+	// we just want to extract all the URLs from the sitemap
+	outlinks = append(outlinks, assets...)
+	return outlinks, nil
+}

--- a/internal/pkg/postprocessor/extractor/xml_test.go
+++ b/internal/pkg/postprocessor/extractor/xml_test.go
@@ -195,8 +195,8 @@ func TestXML(t *testing.T) {
 	}
 }
 
-// TestIsSitemapXML covers multiple scenarios.
-func TestIsSitemapXML(t *testing.T) {
+// TestSitemapXMLOutlinkExtractor covers multiple scenarios.
+func TestSitemapXMLOutlinkExtractor(t *testing.T) {
 	tests := []struct {
 		name    string
 		xmlData string
@@ -296,6 +296,7 @@ func TestIsSitemapXML(t *testing.T) {
 		},
 	}
 
+	extractor := SitemapXMLOutlinkExtractor{}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			// Construct a minimal FakeURL with your test data as body
@@ -315,7 +316,7 @@ func TestIsSitemapXML(t *testing.T) {
 
 			URLObj.SetBody(spooledTempFile)
 
-			got := IsSitemapXML(URLObj)
+			got := extractor.Match(URLObj)
 			if got != tc.want {
 				t.Errorf("IsSitemapXML(%q) = %v, want %v", tc.xmlData, got, tc.want)
 			}

--- a/internal/pkg/postprocessor/outlinks.go
+++ b/internal/pkg/postprocessor/outlinks.go
@@ -14,6 +14,21 @@ import (
 	"github.com/internetarchive/Zeno/pkg/models"
 )
 
+type OutlinkExtractor interface {
+	Match(*models.URL) bool
+	Extract(*models.URL) ([]*models.URL, error)
+}
+
+var outlinkExtractors = []OutlinkExtractor{
+	truthsocial.TruthsocialAccountOutlinkExtractor{},
+	truthsocial.TruthsocialAccountLookupOutlinkExtractor{},
+	extractor.ObjectStorageOutlinkExtractor{},
+	extractor.SitemapXMLOutlinkExtractor{},
+	extractor.HTMLOutlinkExtractor{},
+	extractor.PDFOutlinkExtractor{},
+	reddit.RedditPostAPIOutlinkExtractor{},
+}
+
 func extractOutlinks(item *models.Item) (outlinks []*models.URL, err error) {
 	var (
 		contentType = item.GetURL().GetResponse().Header.Get("Content-Type")
@@ -28,56 +43,14 @@ func extractOutlinks(item *models.Item) (outlinks []*models.URL, err error) {
 	}
 
 	// Run specific extractors
-	switch {
-	case truthsocial.IsAccountURL(item.GetURL()):
-		outlinks, err = truthsocial.GenerateAccountLookupURL(item.GetURL())
-		if err != nil {
-			logger.Error("unable to extract outlinks", "extractor", "truthsocial.GenerateAccountLookupURL", "err", err.Error(), "item", item.GetShortID(), "url", item.GetURL())
-			return outlinks, err
+	for _, p := range outlinkExtractors {
+		if p.Match(item.GetURL()) {
+			outlinks, err = p.Extract(item.GetURL())
+			break
 		}
-	case truthsocial.IsAccountLookupURL(item.GetURL()):
-		outlinks, err = truthsocial.GenerateOutlinksURLsFromLookup(item.GetURL())
-		if err != nil {
-			logger.Error("unable to extract outlinks", "extractor", "truthsocial.GenerateOutlinksURLsFromLookup", "err", err.Error(), "item", item.GetShortID(), "url", item.GetURL())
-			return outlinks, err
-		}
-	case extractor.IsObjectStorage(item.GetURL()):
-		outlinks, err = extractor.ObjectStorage(item.GetURL())
-		if err != nil {
-			logger.Error("unable to extract outlinks from ObjectStorage", "extractor", "ObjectStorage", "err", err.Error(), "item", item.GetShortID(), "url", item.GetURL())
-			return outlinks, err
-		}
-	case extractor.IsSitemapXML(item.GetURL()):
-		var assets []*models.URL
+	}
 
-		assets, outlinks, err = extractor.XML(item.GetURL())
-		if err != nil {
-			logger.Error("unable to extract outlinks", "extractor", "XML", "err", err.Error(), "item", item.GetShortID(), "url", item.GetURL())
-			return outlinks, err
-		}
-
-		// Here we don't care about the difference between assets and outlinks,
-		// we just want to extract all the URLs from the sitemap
-		outlinks = append(outlinks, assets...)
-	case extractor.IsHTML(item.GetURL()):
-		outlinks, err = extractor.HTMLOutlinks(item.GetURL())
-		if err != nil {
-			logger.Error("unable to extract outlinks", "extractor", "HTMLOutlinks", "err", err.Error(), "item", item.GetShortID(), "url", item.GetURL())
-			return outlinks, err
-		}
-	case extractor.IsPDF(item.GetURL()):
-		outlinks, err = extractor.PDF(item.GetURL())
-		if err != nil {
-			logger.Error("unable to extract outlinks", "extractor", "PDF", "err", err.Error(), "item", item.GetShortID(), "url", item.GetURL())
-			return outlinks, err
-		}
-	case reddit.IsPostAPI(item.GetURL()):
-		outlinks, err = reddit.ExtractAPIPostPermalinks(item.GetURL())
-		if err != nil {
-			logger.Error("unable to extract outlinks", "extractor", "reddit.ExtractAPIPostPermalinks", "err", err.Error(), "item", item.GetShortID(), "url", item.GetURL())
-			return outlinks, err
-		}
-	default:
+	if outlinks == nil && err == nil {
 		logger.Debug("no extractor used for page", "content-type", contentType, "item", item.GetShortID(), "url", item.GetURL())
 	}
 

--- a/internal/pkg/postprocessor/sitespecific/reddit/api.go
+++ b/internal/pkg/postprocessor/sitespecific/reddit/api.go
@@ -183,14 +183,16 @@ type Post struct {
 }
 
 func IsRedditURL(URL *models.URL) bool {
-    return strings.Contains(URL.String(), "reddit.com")
+	return strings.Contains(URL.String(), "reddit.com")
 }
 
-func IsPostAPI(URL *models.URL) bool {
+type RedditPostAPIOutlinkExtractor struct{}
+
+func (RedditPostAPIOutlinkExtractor) Match(URL *models.URL) bool {
 	return strings.Contains(URL.String(), "reddit.com/api/info.json?id=t3_")
 }
 
-func ExtractAPIPostPermalinks(URL *models.URL) (outlinks []*models.URL, err error) {
+func (RedditPostAPIOutlinkExtractor) Extract(URL *models.URL) (outlinks []*models.URL, err error) {
 	var permalinks []string
 
 	defer URL.RewindBody()

--- a/internal/pkg/postprocessor/sitespecific/truthsocial/account.go
+++ b/internal/pkg/postprocessor/sitespecific/truthsocial/account.go
@@ -45,30 +45,13 @@ type account struct {
 	Fields                    []any `json:"fields"`
 }
 
-func IsAccountLookupURL(URL *models.URL) bool {
-	return accountLookupRegex.MatchString(URL.String())
-}
+type TruthsocialAccountOutlinkExtractor struct{}
 
-func IsAccountURL(URL *models.URL) bool {
+func (TruthsocialAccountOutlinkExtractor) Match(URL *models.URL) bool {
 	return usernameRegex.MatchString(URL.String())
 }
 
-func GenerateAccountLookupURL(URL *models.URL) (outlinks []*models.URL, err error) {
-	// Get the username from the URL
-	username := usernameRegex.FindStringSubmatch(URL.String())
-	if len(username) != 2 {
-		return nil, nil
-	}
-
-	// Generate the outlinks URLs
-	outlinks = append(outlinks, &models.URL{
-		Raw: "https://truthsocial.com/api/v1/accounts/lookup?acct=" + username[1],
-	})
-
-	return outlinks, nil
-}
-
-func GenerateOutlinksURLsFromLookup(URL *models.URL) (outlinks []*models.URL, err error) {
+func (TruthsocialAccountOutlinkExtractor) Extract(URL *models.URL) (outlinks []*models.URL, err error) {
 	defer URL.RewindBody()
 
 	decoder := json.NewDecoder(URL.GetBody())
@@ -89,6 +72,27 @@ func GenerateOutlinksURLsFromLookup(URL *models.URL) (outlinks []*models.URL, er
 			Raw: "https://truthsocial.com/api/v1/accounts/" + account.ID + "/statuses?with_muted=true&only_media=true",
 		},
 	)
+
+	return outlinks, nil
+}
+
+type TruthsocialAccountLookupOutlinkExtractor struct{}
+
+func (TruthsocialAccountLookupOutlinkExtractor) Match(URL *models.URL) bool {
+	return accountLookupRegex.MatchString(URL.String())
+}
+
+func (TruthsocialAccountLookupOutlinkExtractor) Extract(URL *models.URL) (outlinks []*models.URL, err error) {
+	// Get the username from the URL
+	username := usernameRegex.FindStringSubmatch(URL.String())
+	if len(username) != 2 {
+		return nil, nil
+	}
+
+	// Generate the outlinks URLs
+	outlinks = append(outlinks, &models.URL{
+		Raw: "https://truthsocial.com/api/v1/accounts/lookup?acct=" + username[1],
+	})
 
 	return outlinks, nil
 }


### PR DESCRIPTION
The "main" outlink extraction function `extractOutlinks` is reorganized in a major way.

All extractors are converted to use the same interface.

This makes it easier to add more outlink extractors in the future.