### PR TITLE
fix: double hops

### DIFF
--- a/internal/pkg/postprocessor/outlinks.go
+++ b/internal/pkg/postprocessor/outlinks.go
@@ -92,8 +92,7 @@ func extractLinksFromPage(URL *models.URL) (links []*models.URL) {
 	// Validate links
 	for _, link := range rawLinks {
 		links = append(links, &models.URL{
-			Raw:  link,
-			Hops: URL.GetHops() + 1,
+			Raw: link,
 		})
 	}
 

--- a/internal/pkg/postprocessor/sitespecific/reddit/api.go
+++ b/internal/pkg/postprocessor/sitespecific/reddit/api.go
@@ -216,8 +216,7 @@ func (RedditPostAPIOutlinkExtractor) Extract(URL *models.URL) (outlinks []*model
 
 	for _, rawOutlink := range permalinks {
 		outlinks = append(outlinks, &models.URL{
-			Raw:  rawOutlink,
-			Hops: URL.GetHops() + 1,
+			Raw: rawOutlink,
 		})
 	}
 


### PR DESCRIPTION
close: #392

This bug doesn't do any harm. The `extractOutlinks()` overrides Hops, so nothing happens.