### PR TITLE
Add max outlinks option

### DIFF
--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -67,6 +67,7 @@ type Config struct {
 	MaxCSSJump               int           `mapstructure:"max-css-jump"`
 	MaxRetry                 int           `mapstructure:"max-retry"`
 	MaxContentLengthMiB      int           `mapstructure:"max-content-length"`
+	MaxOutlinks				 int		   `mapstructure:"max-outlinks"`
 	HTTPTimeout              time.Duration `mapstructure:"http-timeout"`
 	ConnReadDeadline         time.Duration `mapstructure:"conn-read-deadline"`
 	CrawlTimeLimit           int           `mapstructure:"crawl-time-limit"`
@@ -262,6 +263,10 @@ func GenerateCrawlConfig() error {
 
 	if config.MaxContentLengthMiB > 0 {
 		slog.Info("Max content length is set, payload over X MiB would be discarded", "X", config.MaxContentLengthMiB)
+	}
+
+	if config.MaxOutlinks > 0 {
+		slog.Info("Max outlinks is set, only the first X outlinks will be processed", "X", config.MaxOutlinks)
 	}
 
 	if config.RandomLocalIP {

--- a/internal/pkg/postprocessor/outlinks.go
+++ b/internal/pkg/postprocessor/outlinks.go
@@ -66,6 +66,7 @@ func extractOutlinks(item *models.Item) (outlinks []*models.URL, err error) {
 	}
 
 	outlinks = filterURLsByProtocol(outlinks)
+	outlinks = filterMaxOutlinks(outlinks)
 
 	// Set the hops level to the item's level + 1
 	for _, outlink := range outlinks {
@@ -109,6 +110,15 @@ func extractLinksFromPage(URL *models.URL) (links []*models.URL) {
 	}
 
 	return links
+}
+
+func filterMaxOutlinks(outlinks []*models.URL) []*models.URL {
+	limit := config.Get().MaxOutlinks
+	outlinksLen := len(outlinks)
+	if limit > 0 && outlinksLen > 0 && outlinksLen > limit {
+		return outlinks[:limit]
+	}
+	return outlinks
 }
 
 func shouldExtractOutlinks(item *models.Item) bool {

--- a/internal/pkg/postprocessor/outlinks_test.go
+++ b/internal/pkg/postprocessor/outlinks_test.go
@@ -25,6 +25,28 @@ func TestFilterURLsByProtocol(t *testing.T) {
 	}
 }
 
+func TestFilterMaxOutlinks(t *testing.T) {
+	var outlinks []*models.URL
+	outlinks = append(outlinks, &models.URL{Raw: "http://e1.com"})
+	outlinks = append(outlinks, &models.URL{Raw: "http://e2.com"})
+	outlinks = append(outlinks, &models.URL{Raw: "http://e3.com"})
+
+	config.InitConfig()
+
+	// no limit by default
+	outlinks2 := filterMaxOutlinks(outlinks)
+	if len(outlinks2) != 3 {
+		t.Errorf("expected 3 outlinks and no filtering, got %d", len(outlinks2))
+	}
+
+	// set limit = 1
+	config.Get().MaxOutlinks = 1
+	outlinks3 := filterMaxOutlinks(outlinks)
+	if len(outlinks3) != 1 {
+		t.Errorf("expected 1 outlink, got %d", len(outlinks3))
+	}
+}
+
 //go:embed testdata/wikipedia_IA.txt
 var wikitext []byte // CC BY-SA 4.0
 


### PR DESCRIPTION
It is useful to be able to set a limit to the number of outlinks you extract.

Add relevant unit test.