### PR TITLE
Simplify postprocessor logging

### DIFF
--- a/internal/pkg/postprocessor/assets.go
+++ b/internal/pkg/postprocessor/assets.go
@@ -25,19 +25,20 @@ func ExtractAssetsOutlinks(item *models.Item) (assets, outlinks []*models.URL, e
 func Extractors(item *models.Item) (assets, outlinks []*models.URL, err error) {
 	logger := log.NewFieldedLogger(&log.Fields{
 		"component": "postprocessor.Extractors",
+		"item": item.GetShortID(),
 	})
 
 	switch {
 	case ina.IsAPIURL(item.GetURL()):
 		INAAssets, err := ina.ExtractMedias(item.GetURL())
 		if err != nil {
-			logger.Error("unable to extract medias from INA", "err", err.Error(), "item", item.GetShortID())
+			logger.Error("unable to extract medias from INA", "err", err.Error())
 			return assets, outlinks, err
 		}
 
 		HTMLAssets, err := extractor.HTMLAssets(item)
 		if err != nil {
-			logger.Error("unable to extract assets", "err", err.Error(), "item", item.GetShortID())
+			logger.Error("unable to extract assets", "err", err.Error())
 			return assets, outlinks, err
 		}
 
@@ -45,38 +46,38 @@ func Extractors(item *models.Item) (assets, outlinks []*models.URL, err error) {
 	case truthsocial.NeedExtraction(item.GetURL()):
 		assets, outlinks, err = truthsocial.ExtractAssets(item)
 		if err != nil {
-			logger.Error("unable to extract assets from TruthSocial", "err", err.Error(), "item", item.GetShortID())
+			logger.Error("unable to extract assets from TruthSocial", "err", err.Error())
 			return assets, outlinks, err
 		}
 	case extractor.IsM3U8(item.GetURL()):
 		assets, err = extractor.M3U8(item.GetURL())
 		if err != nil {
-			logger.Error("unable to extract assets", "err", err.Error(), "item", item.GetShortID())
+			logger.Error("unable to extract assets", "err", err.Error())
 			return assets, outlinks, err
 		}
 	case extractor.IsJSON(item.GetURL()):
 		assets, outlinks, err = extractor.JSON(item.GetURL())
 		if err != nil {
-			logger.Error("unable to extract assets", "err", err.Error(), "item", item.GetShortID())
+			logger.Error("unable to extract assets", "err", err.Error())
 			return assets, outlinks, err
 		}
 	case extractor.IsXML(item.GetURL()):
 		assets, outlinks, err = extractor.XML(item.GetURL())
 		if err != nil {
-			logger.Error("unable to extract assets", "err", err.Error(), "item", item.GetShortID())
+			logger.Error("unable to extract assets", "err", err.Error())
 			return assets, outlinks, err
 		}
 	case extractor.IsHTML(item.GetURL()):
 		assets, err = extractor.HTMLAssets(item)
 		if err != nil {
-			logger.Error("unable to extract assets", "err", err.Error(), "item", item.GetShortID())
+			logger.Error("unable to extract assets", "err", err.Error())
 			return assets, outlinks, err
 		}
 	case extractor.IsEmbeddedCSS(item):
 		var atImportLinks []*models.URL
 		assets, atImportLinks, err = extractor.ExtractFromURLCSS(item.GetURL())
 
-		logArgs := []any{"item", item.GetShortID(), "links", len(assets), "at_import_links", len(atImportLinks)}
+		logArgs := []any{"links", len(assets), "at_import_links", len(atImportLinks)}
 		if err != nil {
 			logArgs = append(logArgs, "err", err)
 			logger.Error("error extracting assets from CSS", logArgs...)
@@ -86,7 +87,7 @@ func Extractors(item *models.Item) (assets, outlinks []*models.URL, err error) {
 		extractor.AddAtImportLinksToItemChild(item, atImportLinks)
 	default:
 		contentType := item.GetURL().GetResponse().Header.Get("Content-Type")
-		logger.Debug("no extractor used for page", "content-type", contentType, "mime", item.GetURL().GetMIMEType().String(), "item", item.GetShortID())
+		logger.Debug("no extractor used for page", "content-type", contentType, "mime", item.GetURL().GetMIMEType().String())
 		return assets, outlinks, nil
 	}
 
@@ -96,13 +97,14 @@ func Extractors(item *models.Item) (assets, outlinks []*models.URL, err error) {
 func SanitizeAssetsOutlinks(item *models.Item, assets []*models.URL, outlinks []*models.URL, err error) ([]*models.URL, []*models.URL, error) {
 	logger := log.NewFieldedLogger(&log.Fields{
 		"component": "postprocessor.SanitizeAssetsOutlinks",
+		"item": item.GetShortID(),
 	})
 	for i := 0; i < len(assets); {
 		asset := assets[i]
 
 		// Case 1: asset is nil
 		if asset == nil {
-			logger.Debug("asset is nil, removing", "item", item.GetShortID())
+			logger.Debug("asset is nil, removing")
 			assets = slices.Delete(assets, i, i+1)
 			continue // don't increment i, next item is now at same index
 		}
@@ -110,8 +112,7 @@ func SanitizeAssetsOutlinks(item *models.Item, assets []*models.URL, outlinks []
 		// Case 2: asset is a duplicate of the item's URL
 		itemURL := item.GetURL()
 		if itemURL != nil && asset.Raw == itemURL.String() {
-			logger.Debug("removing asset that is a duplicate of the item URL",
-				"item", item.GetShortID(), "asset", asset.Raw)
+			logger.Debug("removing asset that is a duplicate of the item URL", "asset", asset.Raw)
 			assets = slices.Delete(assets, i, i+1)
 			continue // same: skip increment to check the next item now at index i
 		}

--- a/internal/pkg/postprocessor/item.go
+++ b/internal/pkg/postprocessor/item.go
@@ -17,24 +17,25 @@ func postprocessItem(item *models.Item) []*models.Item {
 
 	logger := log.NewFieldedLogger(&log.Fields{
 		"component": "postprocessor.postprocess.postprocessItem",
+		"item_id": item.GetShortID(),
 	})
 
 	outlinks := make([]*models.Item, 0)
 
 	if item.GetStatus() != models.ItemArchived {
-		logger.Debug("item not archived, skipping", "item_id", item.GetShortID())
+		logger.Debug("item not archived, skipping")
 		return outlinks
 	}
 
-	logger.Debug("postprocessing item", "item_id", item.GetShortID())
+	logger.Debug("postprocessing item")
 
 	// Verify if there is any redirection
 	if isStatusCodeRedirect(item.GetURL().GetResponse().StatusCode) {
-		logger.Debug("item is a redirection", "item_id", item.GetShortID())
+		logger.Debug("item is a redirection")
 
 		// Check if the current redirections count doesn't exceed the max allowed
 		if item.GetURL().GetRedirects() >= config.Get().MaxRedirect {
-			logger.Warn("max redirects reached", "item_id", item.GetShortID())
+			logger.Warn("max redirects reached")
 			item.SetStatus(models.ItemCompleted)
 			return outlinks
 		}
@@ -76,21 +77,21 @@ func postprocessItem(item *models.Item) []*models.Item {
 	//    -> CSS @import chains can be very long, the depth control logic for embedded CSS item is in the AddAtImportLinksToItemChild() function separately.
 	// 2. assets capture and domains crawl are disabled
 	if !domainscrawl.Enabled() && item.GetDepthWithoutRedirections() > 2 && !extractor.IsEmbeddedCSS(item) {
-		logger.Debug("item is a child and it's depth (without redirections) is more than 2", "item_id", item.GetShortID())
+		logger.Debug("item is a child and it's depth (without redirections) is more than 2")
 		item.SetStatus(models.ItemCompleted)
 		return outlinks
 	} else if !domainscrawl.Enabled() && (item.GetDepthWithoutRedirections() == 1 && strings.Contains(item.GetURL().GetMIMEType().String(), "html")) {
-		logger.Debug("HTML got extracted as asset, skipping", "item_id", item.GetShortID())
+		logger.Debug("HTML got extracted as asset, skipping")
 		item.SetStatus(models.ItemCompleted)
 		return outlinks
 	} else if config.Get().DisableAssetsCapture && !domainscrawl.Enabled() {
-		logger.Debug("assets capture and domains crawl are disabled", "item_id", item.GetShortID())
+		logger.Debug("assets capture and domains crawl are disabled")
 		item.SetStatus(models.ItemCompleted)
 		return outlinks
 	}
 
 	if item.GetURL().GetResponse() != nil && item.GetURL().GetResponse().StatusCode == 200 {
-		logger.Debug("item is a success", "item_id", item.GetShortID())
+		logger.Debug("item is a success")
 
 		var outlinksFromAssets []*models.URL
 
@@ -101,11 +102,11 @@ func postprocessItem(item *models.Item) []*models.Item {
 
 			assets, outlinksFromAssets, err = ExtractAssetsOutlinks(item)
 			if err != nil {
-				logger.Error("unable to extract assets", "err", err.Error(), "item_id", item.GetShortID())
+				logger.Error("unable to extract assets", "err", err.Error())
 			} else {
 				for i := range assets {
 					if assets[i] == nil {
-						logger.Warn("nil asset", "item", item.GetShortID())
+						logger.Warn("nil asset")
 						continue
 					}
 
@@ -114,7 +115,7 @@ func postprocessItem(item *models.Item) []*models.Item {
 						unescaped, err := url.QueryUnescape(strings.ReplaceAll(assets[i].Raw, "amp;", ""))
 
 						if err != nil {
-							logger.Warn("reddit url unescapable", "item", item.GetShortID(), "asset", assets[i])
+							logger.Warn("reddit url unescapable", "asset", assets[i])
 							continue
 						}
 
@@ -131,7 +132,7 @@ func postprocessItem(item *models.Item) []*models.Item {
 					}
 				}
 
-				logger.Debug("extracted assets", "item_id", item.GetShortID(), "count", len(assets))
+				logger.Debug("extracted assets", "count", len(assets))
 			}
 		}
 
@@ -139,14 +140,14 @@ func postprocessItem(item *models.Item) []*models.Item {
 		if shouldExtractOutlinks(item) {
 			newOutlinks, err := extractOutlinks(item)
 			if err != nil {
-				logger.Error("unable to extract outlinks", "err", err.Error(), "item_id", item.GetShortID())
+				logger.Error("unable to extract outlinks", "err", err.Error())
 			} else {
 				// Append the outlinks found from the assets
 				newOutlinks = append(newOutlinks, outlinksFromAssets...)
 
 				for i := range newOutlinks {
 					if newOutlinks[i] == nil {
-						logger.Warn("nil link", "item_id", item.GetShortID())
+						logger.Warn("nil link")
 						continue
 					}
 
@@ -154,10 +155,10 @@ func postprocessItem(item *models.Item) []*models.Item {
 					// and if its parent is at hop 0, then we need to set the hop count to 0.
 					// TODO: maybe be more flexible than a strict match
 					if domainscrawl.Enabled() && domainscrawl.Match(newOutlinks[i].Raw) {
-						logger.Debug("setting hop count to 0 (domains crawl)", "item_id", item.GetShortID(), "url", newOutlinks[i].Raw)
+						logger.Debug("setting hop count to 0 (domains crawl)", "url", newOutlinks[i].Raw)
 						newOutlinks[i].SetHops(0)
 					} else if domainscrawl.Enabled() && !domainscrawl.Match(newOutlinks[i].Raw) && item.GetURL().GetHops() >= config.Get().MaxHops {
-						logger.Debug("skipping outlink due to hop count", "item_id", item.GetShortID(), "url", newOutlinks[i].Raw)
+						logger.Debug("skipping outlink due to hop count", "url", newOutlinks[i].Raw)
 						continue
 					}
 
@@ -165,7 +166,7 @@ func postprocessItem(item *models.Item) []*models.Item {
 					outlinks = append(outlinks, newOutlinkItem)
 				}
 
-				logger.Debug("extracted outlinks", "item_id", item.GetShortID(), "count", len(newOutlinks))
+				logger.Debug("extracted outlinks", "count", len(newOutlinks))
 			}
 		}
 	}
@@ -174,7 +175,7 @@ func postprocessItem(item *models.Item) []*models.Item {
 	item.GetURL().SetDocumentCache(nil)
 
 	if !item.HasChildren() && !item.HasRedirection() && item.GetStatus() != models.ItemFailed {
-		logger.Debug("item has no children, setting as completed", "item_id", item.GetShortID())
+		logger.Debug("item has no children, setting as completed")
 		item.SetStatus(models.ItemCompleted)
 	}
 


### PR DESCRIPTION
Define `item_id` once on logger init instead of calling it on each logger call.