### PR TITLE
Redundant newItem.SetStatus(models.ItemFresh)

### DIFF
--- a/internal/pkg/reactor/reactor_test.go
+++ b/internal/pkg/reactor/reactor_test.go
@@ -99,7 +99,6 @@ func _testerFunc(tokens, consumers, seeds int, t testing.TB) {
 	for i := 0; i < seeds; i++ {
 		newItem := models.NewItem(&models.URL{Raw: fmt.Sprintf("http://example.com/%d", i)}, "")
 		newItem.SetSource(models.ItemSourceInsert)
-		newItem.SetStatus(models.ItemFresh)
 		mockItems = append(mockItems, newItem)
 	}
 

--- a/internal/pkg/source/hq/consumer.go
+++ b/internal/pkg/source/hq/consumer.go
@@ -168,7 +168,6 @@ func (s *HQ) consumerSender(ctx context.Context, wg *sync.WaitGroup, urlBuffer <
 			}
 			parsedURL.SetHops(pathToHops(URL.Path))
 			newItem := models.NewItemWithID(URL.ID, &parsedURL, URL.Via)
-			newItem.SetStatus(models.ItemFresh)
 			newItem.SetSource(models.ItemSourceHQ)
 
 			if discard {

--- a/internal/pkg/source/lq/consumer.go
+++ b/internal/pkg/source/lq/consumer.go
@@ -155,7 +155,6 @@ func (s *LQ) consumerSender(ctx context.Context, wg *sync.WaitGroup, urlBuffer <
 			}
 			parsedURL.SetHops(int(URL.Hops))
 			newItem := models.NewItemWithID(URL.ID, &parsedURL, URL.Via)
-			newItem.SetStatus(models.ItemFresh)
 			newItem.SetSource(models.ItemSourceQueue)
 
 			if discard {


### PR DESCRIPTION
When we create a new item via `NewItem` or `NewItemWithID`, we set status as `ItemFresh` in the constructor.
So, it is not necessary to set it again.