### PR TITLE
Add live reload of exclusion lists (and switch to go 1.25)

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -52,7 +52,7 @@ func getCMDsFlags(getCmd *cobra.Command) {
 	getCmd.PersistentFlags().StringSlice("exclude-string", []string{}, "Discard any (discovered) URLs containing this string.")
 	getCmd.PersistentFlags().StringSlice("exclusion-file", []string{}, "File containing regex to apply on URLs for exclusion. If the path start with http or https, it will be treated as a URL of a file to download.")
 	getCmd.PersistentFlags().Bool("exclusion-file-live-reload", false, "If turned on, the exclusion file will be reloaded every X seconds. X is defined by the --exclusion-file-live-reload-interval flag. (60 seconds by default)")
-	getCmd.PersistentFlags().Int("exclusion-file-live-reload-interval", 60, "Interval in seconds to reload the exclusion file.")
+	getCmd.PersistentFlags().Duration("exclusion-file-live-reload-interval", time.Minute, "Interval at which to reload the exclusion file.")
 	getCmd.PersistentFlags().Int("max-content-length", 0, "Max content length in MB to download for a single resource.")
 	getCmd.PersistentFlags().Float64("min-space-required", 0, "Minimum space required in GB to continue the crawl. Default will be 50GB * (total disk space / 256GB) if total disk space is less than 256GB, else 50GB.")
 	getCmd.PersistentFlags().Bool("strict-regex", false, "If turned on, the xurls `strict` regex setting will be used. Otherwise a looser regex will be used.")

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -51,6 +51,8 @@ func getCMDsFlags(getCmd *cobra.Command) {
 	getCmd.PersistentFlags().Int("crawl-max-time-limit", 0, "Number of seconds until the crawl will automatically panic itself. Default to crawl-time-limit + (crawl-time-limit / 10)")
 	getCmd.PersistentFlags().StringSlice("exclude-string", []string{}, "Discard any (discovered) URLs containing this string.")
 	getCmd.PersistentFlags().StringSlice("exclusion-file", []string{}, "File containing regex to apply on URLs for exclusion. If the path start with http or https, it will be treated as a URL of a file to download.")
+	getCmd.PersistentFlags().Bool("exclusion-file-live-reload", false, "If turned on, the exclusion file will be reloaded every X seconds. X is defined by the --exclusion-file-live-reload-interval flag. (60 seconds by default)")
+	getCmd.PersistentFlags().Int("exclusion-file-live-reload-interval", 60, "Interval in seconds to reload the exclusion file.")
 	getCmd.PersistentFlags().Int("max-content-length", 0, "Max content length in MB to download for a single resource.")
 	getCmd.PersistentFlags().Float64("min-space-required", 0, "Minimum space required in GB to continue the crawl. Default will be 50GB * (total disk space / 256GB) if total disk space is less than 256GB, else 50GB.")
 	getCmd.PersistentFlags().Bool("strict-regex", false, "If turned on, the xurls `strict` regex setting will be used. Otherwise a looser regex will be used.")

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/internetarchive/Zeno
 
-go 1.24.2
+go 1.25
 
 require (
 	github.com/ImVexed/fasturl v0.0.0-20230304231329-4e41488060f3

--- a/internal/pkg/archiver/archiver.go
+++ b/internal/pkg/archiver/archiver.go
@@ -125,11 +125,16 @@ func Stop() {
 
 		logger.Info("stopped")
 	}
+
 	if globalBucketManager != nil {
 		logger.Debug("closing bucket manager")
 		globalBucketManager.Close()
 		logger.Info("closed bucket manager")
 	}
+
+	// Cancel config related contexts
+	// e.g. the goroutine that watches for exclusions file changes
+	config.Cancel()
 }
 
 func (a *archiver) worker(workerID string) {
@@ -187,7 +192,7 @@ func archive(workerID string, seed *models.Item) {
 	logger := log.NewFieldedLogger(&log.Fields{
 		"component": "archiver.archive",
 		"worker_id": workerID,
-		"seed_id": seed.GetShortID(),
+		"seed_id":   seed.GetShortID(),
 	})
 
 	var (

--- a/internal/pkg/archiver/archiver.go
+++ b/internal/pkg/archiver/archiver.go
@@ -134,7 +134,8 @@ func Stop() {
 
 	// Cancel config related contexts
 	// e.g. the goroutine that watches for exclusions file changes
-	config.Cancel()
+	config.Get().Cancel()
+	logger.Info("stopped config related contexts")
 }
 
 func (a *archiver) worker(workerID string) {

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -149,20 +149,20 @@ var (
 func (c *Config) SetContext(ctx context.Context) {
 	if ctx == nil {
 		// Create a new context with cancel if none is provided
-		config.ctx, config.cancel = context.WithCancel(context.Background())
+		c.ctx, c.cancel = context.WithCancel(context.Background())
 	} else {
 		// Use the provided context
-		config.ctx, config.cancel = context.WithCancel(ctx)
+		c.ctx, c.cancel = context.WithCancel(ctx)
 	}
 }
 
 // Add this method to cancel the package's context
 func (c *Config) Cancel() {
-	if !atomic.CompareAndSwapInt32(&config.cancellationRequested, 0, 1) {
+	if !atomic.CompareAndSwapInt32(&c.cancellationRequested, 0, 1) {
 		return // Already cancelled
 	}
-	if config.cancel != nil {
-		config.cancel()
+	if c.cancel != nil {
+		c.cancel()
 	}
 }
 

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -33,53 +33,55 @@ type Config struct {
 	DisableSeencheck bool `mapstructure:"disable-seencheck"`
 	UseSeencheck     bool
 
-	UserAgent                string        `mapstructure:"user-agent"`
-	Cookies                  string        `mapstructure:"cookies"`
-	WARCPrefix               string        `mapstructure:"warc-prefix"`
-	WARCOperator             string        `mapstructure:"warc-operator"`
-	WARCTempDir              string        `mapstructure:"warc-temp-dir"`
-	WARCSize                 int           `mapstructure:"warc-size"`
-	WARCOnDisk               bool          `mapstructure:"warc-on-disk"`
-	WARCPoolSize             int           `mapstructure:"warc-pool-size"`
-	WARCQueueSize            int           `mapstructure:"warc-queue-size"`
-	WARCDedupeSize           int           `mapstructure:"warc-dedupe-size"`
-	WARCWriteAsync           bool          `mapstructure:"async-warc-write"`
-	WARCDiscardStatus        []int         `mapstructure:"warc-discard-status"`
-	CDXDedupeServer          string        `mapstructure:"warc-cdx-dedupe-server"`
-	CDXCookie                string        `mapstructure:"warc-cdx-cookie"`
-	DoppelgangerDedupeServer string        `mapstructure:"warc-doppelganger-dedupe-server"`
-	HQAddress                string        `mapstructure:"hq-address"`
-	HQKey                    string        `mapstructure:"hq-key"`
-	HQSecret                 string        `mapstructure:"hq-secret"`
-	HQProject                string        `mapstructure:"hq-project"`
-	HQBatchSize              int           `mapstructure:"hq-batch-size"`
-	HQBatchConcurrency       int           `mapstructure:"hq-batch-concurrency"`
-	DisableHTMLTag           []string      `mapstructure:"disable-html-tag"`
-	ExcludeHosts             []string      `mapstructure:"exclude-host"`
-	IncludeHosts             []string      `mapstructure:"include-host"`
-	IncludeString            []string      `mapstructure:"include-string"`
-	ExcludeString            []string      `mapstructure:"exclude-string"`
-	ExclusionFile            []string      `mapstructure:"exclusion-file"`
-	WorkersCount             int           `mapstructure:"workers"`
-	MaxConcurrentAssets      int           `mapstructure:"max-concurrent-assets"`
-	MaxHops                  int           `mapstructure:"max-hops"`
-	MaxRedirect              int           `mapstructure:"max-redirect"`
-	MaxCSSJump               int           `mapstructure:"max-css-jump"`
-	MaxRetry                 int           `mapstructure:"max-retry"`
-	MaxContentLengthMiB      int           `mapstructure:"max-content-length"`
-	MaxOutlinks				 int		   `mapstructure:"max-outlinks"`
-	HTTPTimeout              time.Duration `mapstructure:"http-timeout"`
-	ConnReadDeadline         time.Duration `mapstructure:"conn-read-deadline"`
-	CrawlTimeLimit           int           `mapstructure:"crawl-time-limit"`
-	CrawlMaxTimeLimit        int           `mapstructure:"crawl-max-time-limit"`
-	MinSpaceRequired         float64       `mapstructure:"min-space-required"`
-	DomainsCrawl             []string      `mapstructure:"domains-crawl"`
-	CaptureAlternatePages    bool          `mapstructure:"capture-alternate-pages"`
-	StrictRegex              bool          `mapstructure:"strict-regex"`
-	DisableLocalDedupe       bool          `mapstructure:"disable-local-dedupe"`
-	CertValidation           bool          `mapstructure:"cert-validation"`
-	DisableAssetsCapture     bool          `mapstructure:"disable-assets-capture"`
-	UseHQ                    bool          // Special field to check if HQ is enabled depending on the command called
+	UserAgent                       string        `mapstructure:"user-agent"`
+	Cookies                         string        `mapstructure:"cookies"`
+	WARCPrefix                      string        `mapstructure:"warc-prefix"`
+	WARCOperator                    string        `mapstructure:"warc-operator"`
+	WARCTempDir                     string        `mapstructure:"warc-temp-dir"`
+	WARCSize                        int           `mapstructure:"warc-size"`
+	WARCOnDisk                      bool          `mapstructure:"warc-on-disk"`
+	WARCPoolSize                    int           `mapstructure:"warc-pool-size"`
+	WARCQueueSize                   int           `mapstructure:"warc-queue-size"`
+	WARCDedupeSize                  int           `mapstructure:"warc-dedupe-size"`
+	WARCWriteAsync                  bool          `mapstructure:"async-warc-write"`
+	WARCDiscardStatus               []int         `mapstructure:"warc-discard-status"`
+	CDXDedupeServer                 string        `mapstructure:"warc-cdx-dedupe-server"`
+	CDXCookie                       string        `mapstructure:"warc-cdx-cookie"`
+	DoppelgangerDedupeServer        string        `mapstructure:"warc-doppelganger-dedupe-server"`
+	HQAddress                       string        `mapstructure:"hq-address"`
+	HQKey                           string        `mapstructure:"hq-key"`
+	HQSecret                        string        `mapstructure:"hq-secret"`
+	HQProject                       string        `mapstructure:"hq-project"`
+	HQBatchSize                     int           `mapstructure:"hq-batch-size"`
+	HQBatchConcurrency              int           `mapstructure:"hq-batch-concurrency"`
+	DisableHTMLTag                  []string      `mapstructure:"disable-html-tag"`
+	ExcludeHosts                    []string      `mapstructure:"exclude-host"`
+	IncludeHosts                    []string      `mapstructure:"include-host"`
+	IncludeString                   []string      `mapstructure:"include-string"`
+	ExcludeString                   []string      `mapstructure:"exclude-string"`
+	ExclusionFile                   []string      `mapstructure:"exclusion-file"`
+	ExclusionFileLiveReload         bool          `mapstructure:"exclusion-file-live-reload"`
+	ExclusionFileLiveReloadInterval int           `mapstructure:"exclusion-file-live-reload-interval"`
+	WorkersCount                    int           `mapstructure:"workers"`
+	MaxConcurrentAssets             int           `mapstructure:"max-concurrent-assets"`
+	MaxHops                         int           `mapstructure:"max-hops"`
+	MaxRedirect                     int           `mapstructure:"max-redirect"`
+	MaxCSSJump                      int           `mapstructure:"max-css-jump"`
+	MaxRetry                        int           `mapstructure:"max-retry"`
+	MaxContentLengthMiB             int           `mapstructure:"max-content-length"`
+	MaxOutlinks                     int           `mapstructure:"max-outlinks"`
+	HTTPTimeout                     time.Duration `mapstructure:"http-timeout"`
+	ConnReadDeadline                time.Duration `mapstructure:"conn-read-deadline"`
+	CrawlTimeLimit                  int           `mapstructure:"crawl-time-limit"`
+	CrawlMaxTimeLimit               int           `mapstructure:"crawl-max-time-limit"`
+	MinSpaceRequired                float64       `mapstructure:"min-space-required"`
+	DomainsCrawl                    []string      `mapstructure:"domains-crawl"`
+	CaptureAlternatePages           bool          `mapstructure:"capture-alternate-pages"`
+	StrictRegex                     bool          `mapstructure:"strict-regex"`
+	DisableLocalDedupe              bool          `mapstructure:"disable-local-dedupe"`
+	CertValidation                  bool          `mapstructure:"cert-validation"`
+	DisableAssetsCapture            bool          `mapstructure:"disable-assets-capture"`
+	UseHQ                           bool          // Special field to check if HQ is enabled depending on the command called
 
 	// Network
 	Proxy         string `mapstructure:"proxy"`
@@ -262,19 +264,19 @@ func GenerateCrawlConfig() error {
 	}
 
 	if config.MaxContentLengthMiB > 0 {
-		slog.Info("Max content length is set, payload over X MiB would be discarded", "X", config.MaxContentLengthMiB)
+		slog.Info("max content length is set, payload over X MiB would be discarded", "X", config.MaxContentLengthMiB)
 	}
 
 	if config.MaxOutlinks > 0 {
-		slog.Info("Max outlinks is set, only the first X outlinks will be processed", "X", config.MaxOutlinks)
+		slog.Info("max outlinks is set, only the first X outlinks will be processed", "X", config.MaxOutlinks)
 	}
 
 	if config.RandomLocalIP {
-		slog.Warn("Random local IP is enabled")
+		slog.Warn("random local IP is enabled")
 	}
 
 	if config.DisableIPv4 && config.DisableIPv6 {
-		slog.Error("Both IPv4 and IPv6 are disabled, at least one of them must be enabled.")
+		slog.Error("both IPv4 and IPv6 are disabled, at least one of them must be enabled.")
 		os.Exit(1)
 	} else if config.DisableIPv4 {
 		slog.Info("IPv4 is disabled")
@@ -283,35 +285,47 @@ func GenerateCrawlConfig() error {
 	}
 
 	if len(config.ExclusionFile) > 0 {
-		for _, file := range config.ExclusionFile {
-			var (
-				regexes []string
-				err     error
-			)
+		if config.ExclusionFileLiveReload {
+			go func() {
+				ticker := time.NewTicker(time.Duration(config.ExclusionFileLiveReloadInterval) * time.Second)
+				defer ticker.Stop()
 
-			if strings.HasPrefix(file, "http://") || strings.HasPrefix(file, "https://") {
-				slog.Info("Reading (remote) exclusion file", "file", file)
-				regexes, err = readRemoteExclusionFile(file)
+				for range ticker.C {
+					var exclusions []*regexp.Regexp
+					for _, file := range config.ExclusionFile {
+						newExclusions, err := loadExclusions(file)
+						if err != nil {
+							slog.Error("failed to reload exclusion file, will retry in X seconds",
+								"file", file,
+								"err", err,
+								"interval", config.ExclusionFileLiveReloadInterval)
+							continue
+						}
+
+						exclusions = append(exclusions, newExclusions...)
+					}
+
+					config.ExclusionRegexes = exclusions
+				}
+			}()
+		} else {
+			var exclusions []*regexp.Regexp
+
+			for _, file := range config.ExclusionFile {
+				newExclusions, err := loadExclusions(file)
 				if err != nil {
 					return err
 				}
-			} else {
-				slog.Info("Reading (local) exclusion file", "file", file)
-				regexes, err = readLocalExclusionFile(file)
-				if err != nil {
-					return err
-				}
+
+				exclusions = append(exclusions, newExclusions...)
 			}
 
-			slog.Info("Compiling exclusion regexes", "regexes", len(regexes))
-			compiledRegexes := compileRegexes(regexes)
-
-			config.ExclusionRegexes = append(config.ExclusionRegexes, compiledRegexes...)
+			config.ExclusionRegexes = exclusions
 		}
 	}
 
 	if len(config.DomainsCrawl) > 0 {
-		slog.Info("Domains crawl enabled", "domains/regex", config.DomainsCrawl)
+		slog.Info("domains crawl enabled", "domains/regex", config.DomainsCrawl)
 		err := domainscrawl.AddElements(config.DomainsCrawl)
 		if err != nil {
 			panic(err)
@@ -321,11 +335,36 @@ func GenerateCrawlConfig() error {
 	return nil
 }
 
+func loadExclusions(file string) ([]*regexp.Regexp, error) {
+	var (
+		regexes []string
+		err     error
+	)
+
+	if strings.HasPrefix(file, "http://") || strings.HasPrefix(file, "https://") {
+		slog.Info("reading (remote) exclusion file", "file", file)
+		regexes, err = readRemoteExclusionFile(file)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		slog.Info("reading (local) exclusion file", "file", file)
+		regexes, err = readLocalExclusionFile(file)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	slog.Info("compiling exclusion regexes", "regexes", len(regexes))
+
+	return compileRegexes(regexes), nil
+}
+
 func compileRegexes(regexes []string) []*regexp.Regexp {
 	var compiledRegexes []*regexp.Regexp
 
 	for _, regex := range regexes {
-		slog.Debug("Compiling regex", "regex", regex)
+		slog.Debug("compiling regex", "regex", regex)
 		compiledRegex := regexp.MustCompile(regex)
 
 		compiledRegexes = append(compiledRegexes, compiledRegex)
@@ -345,6 +384,7 @@ func readLocalExclusionFile(file string) (regexes []string, err error) {
 	for scanner.Scan() {
 		regexes = append(regexes, scanner.Text())
 	}
+
 	return regexes, scanner.Err()
 }
 

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -69,7 +69,7 @@ type Config struct {
 	ExcludeString                   []string      `mapstructure:"exclude-string"`
 	ExclusionFile                   []string      `mapstructure:"exclusion-file"`
 	ExclusionFileLiveReload         bool          `mapstructure:"exclusion-file-live-reload"`
-	ExclusionFileLiveReloadInterval int           `mapstructure:"exclusion-file-live-reload-interval"`
+	ExclusionFileLiveReloadInterval time.Duration `mapstructure:"exclusion-file-live-reload-interval"`
 	WorkersCount                    int           `mapstructure:"workers"`
 	MaxConcurrentAssets             int           `mapstructure:"max-concurrent-assets"`
 	MaxHops                         int           `mapstructure:"max-hops"`
@@ -322,7 +322,7 @@ func GenerateCrawlConfig() error {
 			go func() {
 				defer config.waitGroup.Done()
 
-				ticker := time.NewTicker(time.Duration(config.ExclusionFileLiveReloadInterval) * time.Second)
+				ticker := time.NewTicker(config.ExclusionFileLiveReloadInterval)
 				defer ticker.Stop()
 
 				for {

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -331,7 +331,7 @@ func GenerateCrawlConfig() error {
 		config.setExclusionRegexes(exclusions)
 
 		if config.ExclusionFileLiveReload {
-			config.waitGroup.Go(func() { config.exclusionFileLiveReloader() })
+			config.waitGroup.Go(config.exclusionFileLiveReloader)
 		}
 	}
 

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -283,9 +283,8 @@ func GenerateCrawlConfig() error {
 		slog.Info("IPv6 is disabled")
 	}
 
+	config.exclusionRegexes.Store([]*regexp.Regexp(nil))
 	if len(config.ExclusionFile) > 0 {
-		config.exclusionRegexes.Store([]*regexp.Regexp(nil))
-
 		if config.ExclusionFileLiveReload {
 			go func() {
 				ticker := time.NewTicker(time.Duration(config.ExclusionFileLiveReloadInterval) * time.Second)

--- a/internal/pkg/config/exclusions.go
+++ b/internal/pkg/config/exclusions.go
@@ -75,7 +75,11 @@ func (c *Config) readRemoteExclusionFile(URL string) (regexes []string, err erro
 	// Read file line by line
 	scanner := bufio.NewScanner(resp.Body)
 	for scanner.Scan() {
-		regexes = append(regexes, scanner.Text())
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		regexes = append(regexes, line)
 	}
 	return regexes, scanner.Err()
 }

--- a/internal/pkg/config/exclusions.go
+++ b/internal/pkg/config/exclusions.go
@@ -1,0 +1,104 @@
+package config
+
+import (
+	"bufio"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+)
+
+func (c *Config) GetExclusionRegexes() []*regexp.Regexp {
+	return c.exclusionRegexes.Load().([]*regexp.Regexp)
+}
+
+func (c *Config) setExclusionRegexes(next []*regexp.Regexp) {
+	c.exclusionRegexes.Store(next)
+}
+
+func loadExclusions(file string) ([]*regexp.Regexp, error) {
+	var (
+		regexes []string
+		err     error
+	)
+
+	if strings.HasPrefix(file, "http://") || strings.HasPrefix(file, "https://") {
+		slog.Info("reading (remote) exclusion file", "file", file)
+		regexes, err = readRemoteExclusionFile(file)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		slog.Info("reading (local) exclusion file", "file", file)
+		regexes, err = readLocalExclusionFile(file)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	slog.Info("compiling exclusion regexes", "regexes", len(regexes))
+
+	return compileRegexes(regexes), nil
+}
+
+func compileRegexes(regexes []string) []*regexp.Regexp {
+	var compiledRegexes []*regexp.Regexp
+
+	for _, regex := range regexes {
+		slog.Debug("compiling regex", "regex", regex)
+		compiledRegex := regexp.MustCompile(regex)
+
+		compiledRegexes = append(compiledRegexes, compiledRegex)
+	}
+
+	return compiledRegexes
+}
+
+func readLocalExclusionFile(file string) (regexes []string, err error) {
+	f, err := os.Open(file)
+	if err != nil {
+		return regexes, err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		regexes = append(regexes, scanner.Text())
+	}
+
+	return regexes, scanner.Err()
+}
+
+func readRemoteExclusionFile(URL string) (regexes []string, err error) {
+	httpClient := &http.Client{
+		Timeout: time.Second * 5,
+	}
+
+	req, err := http.NewRequest(http.MethodGet, URL, nil)
+	if err != nil {
+		return regexes, err
+	}
+
+	req.Header.Set("User-Agent", config.UserAgent)
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return regexes, err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return regexes, fmt.Errorf("failed to download exclusion file: %s", resp.Status)
+	}
+
+	// Read file line by line
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		regexes = append(regexes, scanner.Text())
+	}
+	return regexes, scanner.Err()
+}

--- a/internal/pkg/config/exclusions.go
+++ b/internal/pkg/config/exclusions.go
@@ -105,7 +105,11 @@ func readLocalExclusionFile(file string) (regexes []string, err error) {
 
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
-		regexes = append(regexes, scanner.Text())
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		regexes = append(regexes, line)
 	}
 
 	return regexes, scanner.Err()

--- a/internal/pkg/config/exclusions.go
+++ b/internal/pkg/config/exclusions.go
@@ -12,8 +12,6 @@ import (
 )
 
 func (c *Config) exclusionFileLiveReloader() {
-	defer config.waitGroup.Done()
-
 	ticker := time.NewTicker(config.ExclusionFileLiveReloadInterval)
 	defer ticker.Stop()
 

--- a/internal/pkg/log/log.go
+++ b/internal/pkg/log/log.go
@@ -24,7 +24,6 @@ func Start() error {
 		config := makeConfig()
 		multiLogger = config.makeMultiLogger()
 	})
-
 	if multiLogger == nil {
 		return ErrLoggerAlreadyInitialized
 	}

--- a/internal/pkg/preprocessor/preprocessor.go
+++ b/internal/pkg/preprocessor/preprocessor.go
@@ -155,7 +155,7 @@ func preprocess(workerID string, seed *models.Item) {
 	logger := log.NewFieldedLogger(&log.Fields{
 		"component": "preprocessor.preprocess",
 		"worker_id": workerID,
-		"seed_id": seed.GetShortID(),
+		"seed_id":   seed.GetShortID(),
 	})
 
 	operatingDepth := seed.GetMaxDepth()
@@ -211,7 +211,7 @@ func preprocess(workerID string, seed *models.Item) {
 		// Apply exclusion filters even if it passed inclusion
 		if utils.StringContainsSliceElements(items[i].GetURL().GetParsed().Host, config.Get().ExcludeHosts) ||
 			utils.StringContainsSliceElements(items[i].GetURL().String(), config.Get().ExcludeString) ||
-			matchRegexExclusion(config.Get().ExclusionRegexes, items[i]) {
+			matchRegexExclusion(config.Get().GetExclusionRegexes(), items[i]) {
 
 			logger.Debug("URL excluded (matches exclusion filters)",
 				"item_id", items[i].GetShortID(),


### PR DESCRIPTION
This PR adds the capability to "live reload" the exclusion files.

It is off by default, I would like the opposite but I didn't want to implement a breaking change, we can discuss it if someone thinks it should be on by default.

There is a new setting `--exclusion-file-live-reload` to enable it, by default it reloads the files every 60 seconds, but this can be changed with `--exclusion-file-live-reload-interval` which takes a int corresponding to the number of seconds between each reload.

It works with both file on disk, and remotely. It's a very simple implementation, there are ways we could make it more efficient, it will certainly come in a future PR when I have more time to allow to it.