### PR TITLE
Remove multiple redundant stats.Init()

### DIFF
--- a/internal/pkg/archiver/archiver.go
+++ b/internal/pkg/archiver/archiver.go
@@ -55,8 +55,6 @@ func Start(inputChan, outputChan chan *models.Item) error {
 		"component": "archiver",
 	})
 
-	stats.Init()
-
 	once.Do(func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		globalArchiver = &archiver{

--- a/internal/pkg/postprocessor/postprocessor.go
+++ b/internal/pkg/postprocessor/postprocessor.go
@@ -35,8 +35,6 @@ func Start(inputChan, outputChan chan *models.Item) error {
 		"component": "postprocessor",
 	})
 
-	stats.Init()
-
 	once.Do(func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		globalPostprocessor = &postprocessor{

--- a/internal/pkg/preprocessor/preprocessor.go
+++ b/internal/pkg/preprocessor/preprocessor.go
@@ -50,8 +50,6 @@ func Start(inputChan, outputChan chan *models.Item) error {
 		"component": "preprocessor",
 	})
 
-	stats.Init()
-
 	once.Do(func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		globalPreprocessor = &preprocessor{

--- a/internal/pkg/source/hq/hq.go
+++ b/internal/pkg/source/hq/hq.go
@@ -8,7 +8,6 @@ import (
 	"github.com/internetarchive/Zeno/internal/pkg/config"
 	"github.com/internetarchive/Zeno/internal/pkg/log"
 	"github.com/internetarchive/Zeno/internal/pkg/reactor"
-	"github.com/internetarchive/Zeno/internal/pkg/stats"
 	"github.com/internetarchive/Zeno/pkg/models"
 	"github.com/internetarchive/gocrawlhq"
 )
@@ -40,8 +39,6 @@ func (s *HQ) Start(finishChan, produceChan chan *models.Item) error {
 	logger = log.NewFieldedLogger(&log.Fields{
 		"component": "hq",
 	})
-
-	stats.Init()
 
 	once.Do(func() {
 		ctx, cancel := context.WithCancel(context.Background())

--- a/internal/pkg/source/lq/lq.go
+++ b/internal/pkg/source/lq/lq.go
@@ -7,7 +7,6 @@ import (
 	"github.com/internetarchive/Zeno/internal/pkg/config"
 	"github.com/internetarchive/Zeno/internal/pkg/log"
 	"github.com/internetarchive/Zeno/internal/pkg/reactor"
-	"github.com/internetarchive/Zeno/internal/pkg/stats"
 	"github.com/internetarchive/Zeno/pkg/models"
 )
 
@@ -37,8 +36,6 @@ func (s *LQ) Start(finishChan, produceChan chan *models.Item) error {
 	logger = log.NewFieldedLogger(&log.Fields{
 		"component": "lq",
 	})
-
-	stats.Init()
 
 	once.Do(func() {
 		ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
We keep `stats.Init()` in the pipeline where all components are initialized and remove every other `stats.Init()` call.

Using `stats.Init()` multiple times doesn't have any effect since it uses `sync.Once` to run stats init only once.