### PR TITLE
Remove multiple redundant log.Start()

### DIFF
--- a/internal/pkg/archiver/archiver.go
+++ b/internal/pkg/archiver/archiver.go
@@ -50,7 +50,6 @@ var (
 
 // Start initializes the internal archiver structure, start the WARC writer and start routines, should only be called once and returns an error if called more than once
 func Start(inputChan, outputChan chan *models.Item) error {
-	log.Start()
 	logger = log.NewFieldedLogger(&log.Fields{
 		"component": "archiver",
 	})

--- a/internal/pkg/finisher/finisher.go
+++ b/internal/pkg/finisher/finisher.go
@@ -32,7 +32,6 @@ var (
 // Start initializes the global finisher with the given input channel.
 // This method can only be called once.
 func Start(inputChan, sourceFinishedChan, sourceProducedChan chan *models.Item) error {
-	log.Start()
 	logger = log.NewFieldedLogger(&log.Fields{
 		"component": "finisher",
 	})

--- a/internal/pkg/postprocessor/postprocessor.go
+++ b/internal/pkg/postprocessor/postprocessor.go
@@ -30,7 +30,6 @@ var (
 // This functions starts the preprocessor responsible for preparing
 // the seeds sent by the reactor for captures
 func Start(inputChan, outputChan chan *models.Item) error {
-	log.Start()
 	logger = log.NewFieldedLogger(&log.Fields{
 		"component": "postprocessor",
 	})

--- a/internal/pkg/preprocessor/preprocessor.go
+++ b/internal/pkg/preprocessor/preprocessor.go
@@ -45,7 +45,6 @@ var (
 
 // Start initializes the internal preprocessor structure and start routines, should only be called once and returns an error if called more than once
 func Start(inputChan, outputChan chan *models.Item) error {
-	log.Start()
 	logger = log.NewFieldedLogger(&log.Fields{
 		"component": "preprocessor",
 	})

--- a/internal/pkg/reactor/reactor.go
+++ b/internal/pkg/reactor/reactor.go
@@ -35,7 +35,6 @@ var (
 func Start(maxTokens int, outputChan chan *models.Item) error {
 	var done bool
 
-	log.Start()
 	logger = log.NewFieldedLogger(&log.Fields{
 		"component": "reactor",
 	})

--- a/internal/pkg/source/hq/hq.go
+++ b/internal/pkg/source/hq/hq.go
@@ -36,7 +36,6 @@ func (s *HQ) Start(finishChan, produceChan chan *models.Item) error {
 	var done bool
 	var startErr error
 
-	log.Start()
 	logger = log.NewFieldedLogger(&log.Fields{
 		"component": "hq",
 	})

--- a/internal/pkg/source/lq/lq.go
+++ b/internal/pkg/source/lq/lq.go
@@ -33,7 +33,6 @@ func (s *LQ) Start(finishChan, produceChan chan *models.Item) error {
 	var done bool
 	var startErr error
 
-	log.Start()
 	logger = log.NewFieldedLogger(&log.Fields{
 		"component": "lq",
 	})


### PR DESCRIPTION
We keep `log.Start()` in the pipeline where all components are initialized and remove every other `log.Start()` call.

Using `log.Start()` multiple times doesn't have any effect since it uses `sync.Once` to run log init only once.