### PR TITLE
Create rootContext and share with components

### DIFF
--- a/internal/pkg/consul/consul.go
+++ b/internal/pkg/consul/consul.go
@@ -13,16 +13,9 @@ import (
 	"github.com/internetarchive/Zeno/internal/pkg/log"
 )
 
-var ctx, cancel = context.WithCancel(context.Background())
-
-// Stop cancels the context used to update the TTL check, which will eventually deregister the registered services.
-func Stop() {
-	cancel()
-}
-
 // Register creates a Consul client and registers the service along with a TTL health check.
 // If the program stops updating the TTL, Consul will deregister the service after 30 seconds.
-func Register() error {
+func Register(ctx context.Context) error {
 	logger := log.NewFieldedLogger(&log.Fields{
 		"component": "consul.Register",
 	})

--- a/internal/pkg/controler/watchers/warc.go
+++ b/internal/pkg/controler/watchers/warc.go
@@ -13,12 +13,11 @@ import (
 )
 
 var (
-	wwqCtx, wwqCancel = context.WithCancel(context.Background())
 	wwqWg             sync.WaitGroup
 )
 
 // StartWatchWARCWritingQueue watches the WARC writing queue size and pauses the pipeline if it exceeds the worker count
-func StartWatchWARCWritingQueue(pauseCheckInterval time.Duration, pauseTimeout time.Duration, statsUpdateInterval time.Duration) {
+func StartWatchWARCWritingQueue(wwqCtx context.Context, pauseCheckInterval time.Duration, pauseTimeout time.Duration, statsUpdateInterval time.Duration) {
 	// If Zeno writes WARCs synchronously, no need to check for the queue size and pause the pipeline
 	if config.Get().WARCWriteAsync {
 		// Watch the WARC writing queue size and pause the pipeline if it exceeds the worker count
@@ -110,6 +109,5 @@ func StartWatchWARCWritingQueue(pauseCheckInterval time.Duration, pauseTimeout t
 
 // StopWARCWritingQueueWatcher stops the WARC writing queue watcher by canceling the context and waiting for the goroutine to finish
 func StopWARCWritingQueueWatcher() {
-	wwqCancel()
 	wwqWg.Wait()
 }

--- a/internal/pkg/postprocessor/postprocessor.go
+++ b/internal/pkg/postprocessor/postprocessor.go
@@ -16,7 +16,6 @@ import (
 type postprocessor struct {
 	wg       sync.WaitGroup
 	ctx      context.Context
-	cancel   context.CancelFunc
 	inputCh  chan *models.Item
 	outputCh chan *models.Item
 }
@@ -29,16 +28,14 @@ var (
 
 // This functions starts the preprocessor responsible for preparing
 // the seeds sent by the reactor for captures
-func Start(inputChan, outputChan chan *models.Item) error {
+func Start(ctx context.Context, inputChan, outputChan chan *models.Item) error {
 	logger = log.NewFieldedLogger(&log.Fields{
 		"component": "postprocessor",
 	})
 
 	once.Do(func() {
-		ctx, cancel := context.WithCancel(context.Background())
 		globalPostprocessor = &postprocessor{
 			ctx:      ctx,
-			cancel:   cancel,
 			inputCh:  inputChan,
 			outputCh: outputChan,
 		}
@@ -59,7 +56,6 @@ func Start(inputChan, outputChan chan *models.Item) error {
 
 func Stop() {
 	if globalPostprocessor != nil {
-		globalPostprocessor.cancel()
 		globalPostprocessor.wg.Wait()
 		logger.Info("stopped")
 	}

--- a/internal/pkg/preprocessor/preprocessor.go
+++ b/internal/pkg/preprocessor/preprocessor.go
@@ -29,7 +29,6 @@ import (
 type preprocessor struct {
 	wg       sync.WaitGroup
 	ctx      context.Context
-	cancel   context.CancelFunc
 	inputCh  chan *models.Item
 	outputCh chan *models.Item
 
@@ -44,16 +43,14 @@ var (
 )
 
 // Start initializes the internal preprocessor structure and start routines, should only be called once and returns an error if called more than once
-func Start(inputChan, outputChan chan *models.Item) error {
+func Start(ctx context.Context, inputChan, outputChan chan *models.Item) error {
 	logger = log.NewFieldedLogger(&log.Fields{
 		"component": "preprocessor",
 	})
 
 	once.Do(func() {
-		ctx, cancel := context.WithCancel(context.Background())
 		globalPreprocessor = &preprocessor{
 			ctx:      ctx,
-			cancel:   cancel,
 			inputCh:  inputChan,
 			outputCh: outputChan,
 		}
@@ -75,7 +72,6 @@ func Start(inputChan, outputChan chan *models.Item) error {
 // Stop stops the preprocessor routines
 func Stop() {
 	if globalPreprocessor != nil {
-		globalPreprocessor.cancel()
 		globalPreprocessor.wg.Wait()
 		logger.Info("stopped")
 	}

--- a/internal/pkg/reactor/reactor.go
+++ b/internal/pkg/reactor/reactor.go
@@ -14,7 +14,6 @@ import (
 type reactor struct {
 	tokenPool    chan struct{}      // Token pool to control asset count
 	ctx          context.Context    // Context for stopping the reactor
-	cancel       context.CancelFunc // Context's cancel func
 	freezeCtx    context.Context    // Context for freezing the reactor
 	freezeCancel context.CancelFunc // Freezing context's cancel func
 	input        chan *models.Item  // Combined input channel for source and feedback
@@ -32,7 +31,7 @@ var (
 
 // Start initializes the global reactor with the given maximum tokens.
 // This method can only be called once.
-func Start(maxTokens int, outputChan chan *models.Item) error {
+func Start(ctx context.Context, maxTokens int, outputChan chan *models.Item) error {
 	var done bool
 
 	logger = log.NewFieldedLogger(&log.Fields{
@@ -40,12 +39,10 @@ func Start(maxTokens int, outputChan chan *models.Item) error {
 	})
 
 	once.Do(func() {
-		ctx, cancel := context.WithCancel(context.Background())
 		freezeCtx, freezeCancel := context.WithCancel(ctx)
 		globalReactor = &reactor{
 			tokenPool:    make(chan struct{}, maxTokens),
 			ctx:          ctx,
-			cancel:       cancel,
 			freezeCtx:    freezeCtx,
 			freezeCancel: freezeCancel,
 			input:        make(chan *models.Item, maxTokens),
@@ -69,7 +66,6 @@ func Start(maxTokens int, outputChan chan *models.Item) error {
 func Stop() {
 	if globalReactor != nil {
 		logger.Debug("received stop signal")
-		globalReactor.cancel()
 		globalReactor.wg.Wait()
 		close(globalReactor.input)
 		once = sync.Once{}


### PR DESCRIPTION
Its not a good practice to create a separate context for each component without any special reasons.

We refactor to create a `rootContext` in `pipeline.Start` and pass it to many components.

One initial benefit of this approach is that you don't need to call `cancel()` in the "Stop" function of all components.
E.g. `consul.Stop()` is dropped because it isn't needed at all.

Now, `rootContextCancel()` is called in `pipeline.Stop` and all components using the `rootContext` are notified.