### PR TITLE
refactor(test): replace the socket logging with `net.Pipe()`

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -42,8 +42,8 @@ func Prepare() *cobra.Command {
 	// Define flags and configuration settings
 	rootCmd.PersistentFlags().String("log-level", "info", "stdout log level (debug, info, warn, error)")
 	rootCmd.PersistentFlags().String("config-file", "", "config file (default is $HOME/zeno-config.yaml)")
-	rootCmd.PersistentFlags().String("log-socket", "", "unix socket log address (e.g. /tmp/zenolog.sock) [NOTE: this flag is only used for e2e and integration tests, NOT for production use]")
-	rootCmd.PersistentFlags().String("log-socket-level", "info", "socket log level")
+	rootCmd.PersistentFlags().Bool("log-e2e", false, "[NOTE: this flag is only used for e2e and integration tests, NOT for production use]")
+	rootCmd.PersistentFlags().String("log-e2e-level", "info", "e2e log level")
 	rootCmd.PersistentFlags().Bool("no-stdout-log", false, "disable stdout logging.")
 	rootCmd.PersistentFlags().Bool("no-stderr-log", false, "disable stderr logging.")
 	rootCmd.PersistentFlags().Bool("no-color-logs", false, "switch the terminal (stdout and stderr) logging handler from [slogcolor] handler to the standard [slog] handler (help ensure compatibility with logging collectors)")

--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -38,9 +38,13 @@ func lazyDial(timeout time.Duration) (net.Conn, error) {
 		case <-ctx.Done():
 			return nil, fmt.Errorf("timeout while waiting for connection")
 		default:
-			if zenolog.E2EConnCfg != nil && zenolog.E2EConnCfg.ConnR != nil {
-				return zenolog.E2EConnCfg.ConnR, nil
+			zenolog.E2eConnMutex.RLock()
+			if zenolog.E2EConnCfg != nil {
+				conn := zenolog.E2EConnCfg.ConnR
+				zenolog.E2eConnMutex.RUnlock()
+				return conn, nil
 			}
+			zenolog.E2eConnMutex.RUnlock()
 			time.Sleep(100 * time.Millisecond) // Retry
 		}
 	}

--- a/e2e/test/cloudflare204/cloudflare204_test.go
+++ b/e2e/test/cloudflare204/cloudflare204_test.go
@@ -2,9 +2,7 @@ package cloudflare204
 
 import (
 	_ "embed"
-	"fmt"
 	"os"
-	"path"
 	"sync"
 	"testing"
 
@@ -48,17 +46,14 @@ func (rm *recordMatcher) ShouldStop() bool {
 func TestCloudFlare204(t *testing.T) {
 	os.RemoveAll("jobs")
 
-	tempSocketPath := path.Join(os.TempDir(), fmt.Sprintf("zeno-%d.sock", os.Getpid()))
-	defer os.Remove(tempSocketPath)
-
 	shouldStopCh := make(chan struct{})
 	rm := &recordMatcher{}
 	wg := &sync.WaitGroup{}
 
 	wg.Add(2)
 
-	go e2e.StartHandleLogRecord(t, wg, rm, tempSocketPath, shouldStopCh)
-	go e2e.ExecuteCmdZenoGetURL(t, wg, tempSocketPath, []string{"http://cp.cloudflare.com/"})
+	go e2e.StartHandleLogRecord(t, wg, rm, shouldStopCh)
+	go e2e.ExecuteCmdZenoGetURL(t, wg, []string{"http://cp.cloudflare.com/"})
 
 	e2e.WaitForGoroutines(t, wg, shouldStopCh)
 	rm.Assert(t)

--- a/e2e/test/nonutf8encoding/contenttype/contenttype_test.go
+++ b/e2e/test/nonutf8encoding/contenttype/contenttype_test.go
@@ -1,9 +1,7 @@
 package contenttype
 
 import (
-	"fmt"
 	"os"
-	"path"
 	"strings"
 	"sync"
 	"testing"
@@ -19,17 +17,14 @@ func TestNonUTF8ContentType(t *testing.T) {
 
 	os.RemoveAll("jobs")
 
-	tempSocketPath := path.Join(os.TempDir(), fmt.Sprintf("zeno-%d.sock", os.Getpid()))
-	defer os.Remove(tempSocketPath)
-
 	shouldStopCh := make(chan struct{})
 	rm := &nonutf8encoding.RecordMatcher{}
 	wg := &sync.WaitGroup{}
 
 	wg.Add(2)
 
-	go e2e.StartHandleLogRecord(t, wg, rm, tempSocketPath, shouldStopCh)
-	go e2e.ExecuteCmdZenoGetURL(t, wg, tempSocketPath, []string{serverURL + "/raw"})
+	go e2e.StartHandleLogRecord(t, wg, rm, shouldStopCh)
+	go e2e.ExecuteCmdZenoGetURL(t, wg, []string{serverURL + "/raw"})
 
 	e2e.WaitForGoroutines(t, wg, shouldStopCh)
 	rm.Assert(t)

--- a/e2e/test/nonutf8encoding/metacharset/metacharset_test.go
+++ b/e2e/test/nonutf8encoding/metacharset/metacharset_test.go
@@ -1,9 +1,7 @@
 package contenttype
 
 import (
-	"fmt"
 	"os"
-	"path"
 	"strings"
 	"sync"
 	"testing"
@@ -19,17 +17,14 @@ func TestNonUTF8HTMLMetaCharset(t *testing.T) {
 
 	os.RemoveAll("jobs")
 
-	tempSocketPath := path.Join(os.TempDir(), fmt.Sprintf("zeno-%d.sock", os.Getpid()))
-	defer os.Remove(tempSocketPath)
-
 	shouldStopCh := make(chan struct{})
 	rm := &nonutf8encoding.RecordMatcher{}
 	wg := &sync.WaitGroup{}
 
 	wg.Add(2)
 
-	go e2e.StartHandleLogRecord(t, wg, rm, tempSocketPath, shouldStopCh)
-	go e2e.ExecuteCmdZenoGetURL(t, wg, tempSocketPath, []string{serverURL + "/meta_decl"})
+	go e2e.StartHandleLogRecord(t, wg, rm, shouldStopCh)
+	go e2e.ExecuteCmdZenoGetURL(t, wg, []string{serverURL + "/meta_decl"})
 
 	e2e.WaitForGoroutines(t, wg, shouldStopCh)
 	rm.Assert(t)

--- a/e2e/test/nxdomain/nxdomain_test.go
+++ b/e2e/test/nxdomain/nxdomain_test.go
@@ -2,9 +2,7 @@ package nxdomain
 
 import (
 	_ "embed"
-	"fmt"
 	"os"
-	"path"
 	"strings"
 	"sync"
 	"testing"
@@ -43,17 +41,14 @@ func (rm *recordMatcher) ShouldStop() bool {
 func TestNXDomain(t *testing.T) {
 	os.RemoveAll("jobs")
 
-	tempSocketPath := path.Join(os.TempDir(), fmt.Sprintf("zeno-%d.sock", os.Getpid()))
-	defer os.Remove(tempSocketPath)
-
 	shouldStopCh := make(chan struct{})
 	rm := &recordMatcher{}
 	wg := &sync.WaitGroup{}
 
 	wg.Add(2)
 
-	go e2e.StartHandleLogRecord(t, wg, rm, tempSocketPath, shouldStopCh)
-	go e2e.ExecuteCmdZenoGetURL(t, wg, tempSocketPath, []string{"http://nxdomain.nxtld/"})
+	go e2e.StartHandleLogRecord(t, wg, rm, shouldStopCh)
+	go e2e.ExecuteCmdZenoGetURL(t, wg, []string{"http://nxdomain.nxtld/"})
 
 	e2e.WaitForGoroutines(t, wg, shouldStopCh)
 	rm.Assert(t)

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -109,8 +109,8 @@ type Config struct {
 	NoStderrLogging  bool   `mapstructure:"no-stderr-log"`
 	NoColorLogging   bool   `mapstructure:"no-color-logs"`
 	NoFileLogging    bool   `mapstructure:"no-log-file"`
-	SocketLogging    string `mapstructure:"log-socket"`
-	SocketLevel      string `mapstructure:"log-socket-level"`
+	E2ELogging       bool   `mapstructure:"log-e2e"`
+	E2ELevel         string `mapstructure:"log-e2e-level"`
 	StdoutLogLevel   string `mapstructure:"log-level"`
 	TUI              bool   `mapstructure:"tui"`
 	TUILogLevel      string `mapstructure:"tui-log-level"`

--- a/internal/pkg/controler/signal.go
+++ b/internal/pkg/controler/signal.go
@@ -10,6 +10,7 @@ import (
 )
 
 var signalWatcherCtx, signalWatcherCancel = context.WithCancel(context.Background())
+var SignalChan = make(chan os.Signal, 1)
 
 // WatchSignals listens for OS signals and handles them gracefully
 func WatchSignals() {
@@ -17,17 +18,16 @@ func WatchSignals() {
 		"component": "controler.signalWatcher",
 	})
 	// Handle OS signals for graceful shutdown
-	signalChan := make(chan os.Signal, 1)
-	signal.Notify(signalChan, syscall.SIGINT, syscall.SIGTERM)
+	signal.Notify(SignalChan, syscall.SIGINT, syscall.SIGTERM)
 
 	select {
 	case <-signalWatcherCtx.Done():
 		return
-	case <-signalChan:
+	case <-SignalChan:
 		logger.Info("received shutdown signal, stopping services...")
 		// Catch a second signal to force exit
 		go func() {
-			<-signalChan
+			<-SignalChan
 			logger.Info("received second shutdown signal, forcing exit...")
 			os.Exit(1)
 		}()

--- a/internal/pkg/log/config.go
+++ b/internal/pkg/log/config.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/MatusOllah/slogcolor"
@@ -21,6 +22,7 @@ import (
 
 var (
 	rotatedLogFile *rotatedFile
+	E2eConnMutex   sync.RWMutex
 	E2EConnCfg     *e2eConnConfig
 )
 
@@ -89,12 +91,14 @@ func makeConfig() *logConfig {
 
 	if config.Get().E2ELogging {
 		connW, connR := net.Pipe() // Use a pipe for testing purposes
-		stdliblog.Println("Client connected!")
+		E2eConnMutex.Lock()
 		E2EConnCfg = &e2eConnConfig{
 			Level: parseLevel(config.Get().E2ELevel),
 			connW: connW,
 			ConnR: connR,
 		}
+		E2eConnMutex.Unlock()
+		stdliblog.Println("E2E connection is ready!")
 	}
 
 	return &logConfig{

--- a/internal/pkg/log/log.go
+++ b/internal/pkg/log/log.go
@@ -36,9 +36,8 @@ func Stop() {
 	if rotatedLogFile != nil {
 		rotatedLogFile.Close()
 	}
-	if socketCfg != nil {
-		socketCfg.NetListener.Close()
-		socketCfg.Conn.Close()
+	if E2EConnCfg != nil {
+		E2EConnCfg.connW.Close()
 	}
 	wg.Wait()
 	multiLogger = nil

--- a/internal/pkg/log/log.go
+++ b/internal/pkg/log/log.go
@@ -36,9 +36,11 @@ func Stop() {
 	if rotatedLogFile != nil {
 		rotatedLogFile.Close()
 	}
+	E2eConnMutex.RLock()
 	if E2EConnCfg != nil {
 		E2EConnCfg.connW.Close()
 	}
+	E2eConnMutex.RUnlock()
 	wg.Wait()
 	multiLogger = nil
 	once = sync.Once{}


### PR DESCRIPTION
It suddenly occurred to me that the e2e test suite runs in the same package as Zeno. I don't need to mess around with sockets to get them communicating.

So I replaced the socket logging file with a `net.Pipe()` and then exposed Zeno's `SignalChannel` to the e2e suite.