### PR TITLE
More versatile HQ client init

### DIFF
--- a/internal/pkg/controler/pipeline.go
+++ b/internal/pkg/controler/pipeline.go
@@ -123,7 +123,7 @@ func startPipeline() {
 	finisherProduceChan := makeStageChannel(config.Get().WorkersCount)
 
 	if config.Get().UseHQ {
-		hqSource := hq.New()
+		hqSource := hq.New(config.Get().HQKey, config.Get().HQSecret, config.Get().HQProject, config.Get().HQAddress)
 		preprocessor.SetSeenchecker(hqSource.SeencheckItem)
 		sourceInterface = hqSource
 	} else {

--- a/internal/pkg/source/hq/hq.go
+++ b/internal/pkg/source/hq/hq.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"sync"
 
-	"github.com/internetarchive/Zeno/internal/pkg/config"
 	"github.com/internetarchive/Zeno/internal/pkg/log"
 	"github.com/internetarchive/Zeno/internal/pkg/reactor"
 	"github.com/internetarchive/Zeno/pkg/models"
@@ -19,6 +18,10 @@ type HQ struct {
 	finishCh  chan *models.Item
 	produceCh chan *models.Item
 	client    *gocrawlhq.Client
+	HQKey     string
+	HQSecret  string
+	HQProject string
+	HQAddress string
 }
 
 var (
@@ -26,8 +29,13 @@ var (
 	logger *log.FieldedLogger
 )
 
-func New() *HQ {
-	return &HQ{}
+func New(HQKey, HQSecret, HQProject, HQAddress string) *HQ {
+	return &HQ{
+		HQKey:     HQKey,
+		HQSecret:  HQSecret,
+		HQProject: HQProject,
+		HQAddress: HQAddress,
+	}
 }
 
 // Start initializes HQ async routines with the given input and output channels.
@@ -41,7 +49,7 @@ func (s *HQ) Start(finishChan, produceChan chan *models.Item) error {
 
 	once.Do(func() {
 		ctx, cancel := context.WithCancel(context.Background())
-		HQclient, err := gocrawlhq.Init(config.Get().HQKey, config.Get().HQSecret, config.Get().HQProject, config.Get().HQAddress, "", 5)
+		HQclient, err := gocrawlhq.Init(s.HQKey, s.HQSecret, s.HQProject, s.HQAddress, "", 5)
 		if err != nil {
 			logger.Error("error initializing crawl HQ client", "err", err.Error(), "func", "hq.Start")
 			cancel()

--- a/internal/pkg/source/hq/websocket.go
+++ b/internal/pkg/source/hq/websocket.go
@@ -36,7 +36,7 @@ func (s *HQ) websocket() {
 
 func (s *HQ) sendIdentify(logger *log.FieldedLogger) {
 	err := s.client.Identify(&gocrawlhq.IdentifyMessage{
-		Project:   config.Get().HQProject,
+		Project:   s.HQProject,
 		Job:       config.Get().Job,
 		IP:        utils.GetOutboundIP().String(),
 		Hostname:  utils.GetHostname(),


### PR DESCRIPTION
Pass `HQKey, HQSecret, HQProject, HQAddress` as params on `HQ.New` instead of loading them via `config.Get()` inside `HQ.Start`.

This way, we can have multiple HQ client instances with different parameters.

This is necessary to be able to create a 2nd HQ client instance which connects an "outlinks" HQ project to send outlinks there.