### PR TITLE
fix multiLogger data race

### DIFF
--- a/internal/pkg/log/log.go
+++ b/internal/pkg/log/log.go
@@ -13,6 +13,7 @@ var (
 	once        sync.Once
 	wg          sync.WaitGroup
 	multiLogger *slog.Logger
+	loggerMu    sync.RWMutex
 
 	TUIRingBuffer *ringbuffer.MP1COverwritingRingBuffer[string]
 )
@@ -20,6 +21,9 @@ var (
 // Start initializes the logging package with the given configuration.
 // If no configuration is provided, it uses the default configuration.
 func Start() error {
+	loggerMu.Lock()
+	defer loggerMu.Unlock()
+
 	once.Do(func() {
 		config := makeConfig()
 		multiLogger = config.makeMultiLogger()
@@ -33,14 +37,19 @@ func Start() error {
 
 // Stop gracefully shuts down the logging system
 func Stop() {
+	loggerMu.Lock()
+	defer loggerMu.Unlock()
+
 	if rotatedLogFile != nil {
 		rotatedLogFile.Close()
 	}
+
 	E2eConnMutex.RLock()
 	if E2EConnCfg != nil {
 		E2EConnCfg.connW.Close()
 	}
 	E2eConnMutex.RUnlock()
+
 	wg.Wait()
 	multiLogger = nil
 	once = sync.Once{}
@@ -48,6 +57,9 @@ func Stop() {
 
 // Debug logs a message at the debug level
 func Debug(msg string, args ...any) {
+	loggerMu.RLock()
+	defer loggerMu.RUnlock()
+
 	if multiLogger != nil {
 		multiLogger.Debug(msg, args...)
 	}
@@ -55,6 +67,9 @@ func Debug(msg string, args ...any) {
 
 // Info logs a message at the info level
 func Info(msg string, args ...any) {
+	loggerMu.RLock()
+	defer loggerMu.RUnlock()
+
 	if multiLogger != nil {
 		multiLogger.Info(msg, args...)
 	}
@@ -62,6 +77,9 @@ func Info(msg string, args ...any) {
 
 // Warn logs a message at the warn level
 func Warn(msg string, args ...any) {
+	loggerMu.RLock()
+	defer loggerMu.RUnlock()
+
 	if multiLogger != nil {
 		multiLogger.Warn(msg, args...)
 	}
@@ -69,6 +87,9 @@ func Warn(msg string, args ...any) {
 
 // Error logs a message at the error level
 func Error(msg string, args ...any) {
+	loggerMu.RLock()
+	defer loggerMu.RUnlock()
+
 	if multiLogger != nil {
 		multiLogger.Error(msg, args...)
 	}

--- a/internal/pkg/log/log_race_test.go
+++ b/internal/pkg/log/log_race_test.go
@@ -1,0 +1,65 @@
+package log
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestLoggerRaceCondition(t *testing.T) {
+	// ensure logger is stopped before starting
+	Stop()
+
+	if err := Start(); err != nil {
+		t.Fatalf("Failed to start logger: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	for range 10 {
+		wg.Go(func() { Debug("message") })
+		wg.Go(func() { Info("message") })
+		wg.Go(func() { Warn("message") })
+		wg.Go(func() { Error("message") })
+	}
+
+	stopped := make(chan struct{})
+	go func() {
+		Stop()
+		close(stopped)
+	}()
+
+	wg.Wait()
+
+	<-stopped
+
+	loggerMu.RLock()
+	defer loggerMu.RUnlock()
+	if multiLogger != nil {
+		t.Error("Logger should be nil after Stop()")
+	}
+}
+
+func TestLoggerNilSafety(t *testing.T) {
+	Stop()
+
+	Debug("Should not panic when logger is nil")
+	Info("Should not panic when logger is nil")
+	Warn("Should not panic when logger is nil")
+	Error("Should not panic when logger is nil")
+
+	if err := Start(); err != nil {
+		t.Fatalf("Failed to start logger: %v", err)
+	}
+
+	Debug("Should log when logger is initialized")
+	Info("Should log when logger is initialized")
+	Warn("Should log when logger is initialized")
+	Error("Should log when logger is initialized")
+
+	Stop()
+
+	loggerMu.RLock()
+	defer loggerMu.RUnlock()
+	if multiLogger != nil {
+		t.Error("Logger should be nil after Stop()")
+	}
+}


### PR DESCRIPTION
fix a data race found in #444.

---

Although this is a data race, it only occurs when the log component is shutting down, which is the last component to be shut down, so this bug does not actually affect Zeno's data integrity.