### PR TITLE
Switch default digest algorithm from SHA1 to BLAKE3

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -114,7 +114,7 @@ func addWARCFlags(getCmd *cobra.Command) {
 	getCmd.PersistentFlags().String("warc-operator", "", "Contact informations of the crawl operator to write in the Warc-Info record in each WARC file.")
 	getCmd.PersistentFlags().String("warc-cdx-dedupe-server", "", "Identify the server to use CDX deduplication. This activates CDX deduplication.")
 	getCmd.PersistentFlags().String("warc-doppelganger-dedupe-server", "", "Identify the server to use doppelganger deduplication. This activates doppelganger deduplication.")
-	getCmd.PersistentFlags().String("warc-digest-algorithm", "blake3", "Digest algorithm to use for WARC records (Block & Payload digests). Possible values are: sha1, sha256, blake3. (note: SHA-1 is cryptographically broken and should not be used due to collision vulnerabilities)")
+	getCmd.PersistentFlags().String("warc-digest-algorithm", "sha256", "Digest algorithm to use for WARC records (Block & Payload digests). Possible values are: sha1, sha256, blake3. (note: SHA-1 is cryptographically broken and should not be used due to collision vulnerabilities)")
 	getCmd.PersistentFlags().Bool("warc-on-disk", false, "Do not use RAM to store payloads when recording traffic to WARCs, everything will happen on disk (usually used to reduce memory usage).")
 	getCmd.PersistentFlags().Int("warc-pool-size", 1, "Number of concurrent WARC files to write.")
 	getCmd.PersistentFlags().Int("warc-queue-size", -1, "Number of WARC records to queue before blocking the workers. Default is the --warc-pool-size.")


### PR DESCRIPTION
## Why this change?
Zeno claims to be a **"state-of-the-art web crawler"**, but its current use of **SHA1** for payload digest calculation is outdated and problematic. SHA1 is cryptographically broken, as demonstrated by [the SHAttered attack](https://shattered.io/), which showed practical collision vulnerabilities. While SHA1 may still be used in some legacy contexts, **its use for deduplication in a modern crawler is unacceptable**, collisions can lead to data integrity issues and false deduplication.

## Why BLAKE3?
BLAKE3 is a *fast, secure, and modern alternative, offering both high performance and strong collision resistance. It is widely recommended for new systems:
- [BLAKE3 vs SHA2/SHA3: Performance and Security](https://kerkour.com/fast-secure-hash-function-sha256-sha512-sha3-blake3)
- [BLAKE2/BLAKE3 as High-Performance Alternatives](https://guptadeepak.com/blake2-and-blake3-high-performance-hashing-alternatives/)
- The web archiving community has also discussed moving away from SHA1 in favor of more robust algorithms ([IIPC #80](https://github.com/iipc/warc-specifications/issues/80)), and BLAKE3 has been mentioned multiple times and stands out as the best choice right now.

## Implementation Note
This PR depends on [#449](https://github.com/internetarchive/Zeno/pull/449), which introduces the `--warc-digest-algorithm` flag, allowing users to override the default if needed.

## Impact
- **Default changes from SHA1 to BLAKE3** for all new digests.
- **Backward compatibility**: new crawls will use BLAKE3 by default, but crawlers can still use SHA1 with `--warc-digest-algorithm sha1`, though this is **not recommended**.
- **Performance**: BLAKE3 is significantly faster than SHA1 while being more secure. (same goes for BLAKE3 vs SHA256 btw)

This change aligns Zeno with modern best practices and reinforces its claim as a state-of-the-art tool.
