### PR TITLE
Add support for confirmed messages through WS

### DIFF
--- a/internal/pkg/source/hq/websocket.go
+++ b/internal/pkg/source/hq/websocket.go
@@ -136,12 +136,7 @@ func handleConfirmedMsg(msg []byte) error {
 		return err
 	}
 
-	if m.Type == "confirmed" {
-		return nil
-	}
-
-	return unknownMsgTypeErr
-
+	return nil
 }
 
 func (s *HQ) sendIdentify(logger *log.FieldedLogger) {

--- a/internal/pkg/source/hq/websocket.go
+++ b/internal/pkg/source/hq/websocket.go
@@ -88,6 +88,8 @@ func dispatchMessageByType(msg []byte) (string, error) {
 	switch m.Type {
 	case "signal":
 		err = handleSignalMsg(msg)
+	case "confirmed":
+		err = handleConfirmedMsg(msg)
 	default:
 		err = unknownMsgTypeErr
 	}
@@ -113,6 +115,33 @@ func handleSignalMsg(msg []byte) error {
 	}
 
 	return nil
+}
+
+func handleConfirmedMsg(msg []byte) error {
+	type confirmedMsg struct {
+		Type    string `json:"type"`
+		Payload struct {
+			Project    string `json:"project"`
+			Job        string `json:"job"`
+			IP         string `json:"ip"`
+			Hostname   string `json:"hostname"`
+			Identifier string `json:"identifier"`
+			Timestamp  int64  `json:"timestamp"`
+			GoVersion  string `json:"goVersion"`
+		} `json:"payload"`
+	}
+	var m confirmedMsg
+
+	if err := json.Unmarshal(msg, &m); err != nil {
+		return err
+	}
+
+	if m.Type == "confirmed" {
+		return nil
+	}
+
+	return unknownMsgTypeErr
+
 }
 
 func (s *HQ) sendIdentify(logger *log.FieldedLogger) {


### PR DESCRIPTION
Our HQ sends confirmation messages after `identify` messages. This should follow that format and ensure we are not spamming the log with unneeded messages. 

@yzqzss please let me know if this works for you as well!