### PR TITLE
refine preprocess error reporting

### DIFF
--- a/internal/pkg/preprocessor/preprocessor.go
+++ b/internal/pkg/preprocessor/preprocessor.go
@@ -138,7 +138,7 @@ func (p *preprocessor) worker(workerID string) {
 				}
 
 				if err := preprocess(workerID, seed); err != nil {
-					panic(fmt.Sprintf("preprocess failed with err: %s" , err.Error()))
+					panic(fmt.Sprintf("preprocess failed with err: %v", err))
 				}
 
 				select {


### PR DESCRIPTION
Stop using `panic()` inside the `preprocess()`, return the error in the main `preprocessor()`.

This is relevant to https://github.com/internetarchive/Zeno/issues/473