### PR TITLE
Return error instead of using panic() in the Reactor

### DIFF
--- a/internal/pkg/reactor/error.go
+++ b/internal/pkg/reactor/error.go
@@ -14,6 +14,8 @@ var (
 
 	// ErrFeedbackItemNotPresent is the error returned when an item was sent to the feedback channel but not found in the state table
 	ErrFeedbackItemNotPresent = errors.New("feedback item not present in state table")
+	// ErrReactorItemPresent is the error returned when a received item is already in the state table
+	ErrReactorItemPresent = errors.New("item already present in reactor")
 	// ErrFinisehdItemNotFound is the error returned when an item been marked as finished but not found in the state table
 	ErrFinisehdItemNotFound = errors.New("markAsFinished item not present in state table")
 )

--- a/internal/pkg/reactor/reactor.go
+++ b/internal/pkg/reactor/reactor.go
@@ -96,7 +96,7 @@ func ReceiveFeedback(item *models.Item) error {
 
 	if !item.IsSeed() {
 		spew.Dump(item)
-		panic("item is not a seed")
+		return models.ErrNotASeed
 	}
 
 	item.SetSource(models.ItemSourceFeedback)
@@ -133,7 +133,7 @@ func ReceiveInsert(item *models.Item) error {
 		logger.Debug("received item", "item", item.GetShortID())
 		if !item.IsSeed() {
 			spew.Dump(item)
-			panic("item is not a seed")
+			return models.ErrNotASeed
 		}
 		if item.GetSource() != models.ItemSourceQueue && item.GetSource() != models.ItemSourceHQ {
 			item.SetSource(models.ItemSourceInsert)
@@ -142,7 +142,7 @@ func ReceiveInsert(item *models.Item) error {
 		if loaded {
 			spew.Dump(loadedItem.(*models.Item))
 			spew.Dump(item)
-			panic("item already present in reactor")
+			return ErrReactorItemPresent
 		}
 
 		globalReactor.input <- item


### PR DESCRIPTION
Methods `ReceiveFeedback` and `ReceiveInsert` already return `error`.

We call `reactor.ReceiveFeedback` in the finisher and we terminate when there is an error so the program behavior doesn't change. https://github.com/internetarchive/Zeno/blob/main/internal/pkg/finisher/finisher.go#L122

We call `reactor.ReceiveInsert` in the pipeline and we terminate when there is an error so the program behavior doesn't change. https://github.com/internetarchive/Zeno/blob/main/internal/pkg/controler/pipeline.go#L161

`models.ErroNotASeed` is already defined, there is no need to make a new error.

Define `ErrReactorItemPresent` because there is no relevant reactor error.

Relevant to issue: https://github.com/internetarchive/Zeno/issues/473