### PR TITLE
fix(docker): upgrades go version to 1.25.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Builder stage
-FROM golang:1.24.3-alpine3.20 AS builder
+FROM golang:1.25.1-alpine3.22 AS builder
 
 # Enable CGO and set platform
 ENV CGO_ENABLED=1 GOOS=linux GOARCH=amd64


### PR DESCRIPTION
Upgrades version of Go used in Dockerfile, fixing a failure caused while building container images: 

```
[1/2] STEP 6/8: RUN go mod download
go: go.mod requires go >= 1.25.1 (running go 1.24.3; GOTOOLCHAIN=local)
subprocess exited with status 1
```