### PR TITLE
Improve startPipeline error handling

### DIFF
--- a/internal/pkg/controler/controler.go
+++ b/internal/pkg/controler/controler.go
@@ -3,7 +3,9 @@ package controler
 
 // Start initializes the pipeline.
 func Start() {
-	startPipeline()
+	if err := startPipeline(); err != nil {
+		panic(err)
+	}
 }
 
 // Stop stops the pipeline.


### PR DESCRIPTION
Return error and use `panic` only once in the controller.

This way its cleaner and it would be easier to use it in tests.

Relevant to: https://github.com/internetarchive/Zeno/issues/473