### PR TITLE
Return errors in config init instead of os.Exit

### DIFF
--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -221,8 +221,7 @@ func InitConfig() error {
 		} else {
 			home, err := os.UserHomeDir()
 			if err != nil {
-				fmt.Println(err)
-				os.Exit(1)
+				return
 			}
 
 			viper.AddConfigPath(home)
@@ -357,8 +356,7 @@ func GenerateCrawlConfig() error {
 	}
 
 	if config.DisableIPv4 && config.DisableIPv6 {
-		slog.Error("both IPv4 and IPv6 are disabled, at least one of them must be enabled.")
-		os.Exit(1)
+		return fmt.Errorf("both IPv4 and IPv6 are disabled, at least one of them must be enabled.")
 	} else if config.DisableIPv4 {
 		slog.Info("IPv4 is disabled")
 	} else if config.DisableIPv6 {


### PR DESCRIPTION
Config already returns errors and terminates when there is an issue. There is no need to use `os.Exit(1)` for these specific cases, return error and the program will terminate anyway where `config.InitConfig` is invoked if it gets an error.

Relevant to: https://github.com/internetarchive/Zeno/issues/473