### PR TITLE
Optimise encodeNonUTF8QueryURLs

### DIFF
--- a/internal/pkg/postprocessor/extractor/html_document_test.go
+++ b/internal/pkg/postprocessor/extractor/html_document_test.go
@@ -120,6 +120,12 @@ func Test_encodeNonUTF8QueryURLs(t *testing.T) {
 			wantUrls: []string{"http://example.com/ABC你好?q=测试", "http://example.com/?q=hello"},
 		},
 		{
+			name:     "UTF-8 bad URL passthrough encoding",
+			encName:  "utf-8",
+			urls:     []string{"://bad.com/ABC你好?q=测试", "http://bad.com/?q=hello"},
+			wantUrls: []string{"://bad.com/ABC你好?q=测试", "http://bad.com/?q=hello"},
+		},
+		{
 			name:     "GBK URLs",
 			encName:  "gbk",
 			urls:     []string{"http://example.com/ABC你好?q=测试", "http://example.com/?q=hello"},


### PR DESCRIPTION
Two optimisations:
We iterate query `key` -> `values` and then iterate each `value` in `values`. We encoded the `key` again and again for each `value`. We only need to do it once. We move the key encoding code outside the `values` loop.

We define `enc.NewEncoder().String()` every time we need to encode a value. We can define `encoder := enc.NewEncoder()` in the beginning and reuse it.

We add a unit test for a bad URL just to be sure.