### PR TITLE
Replace context.TODO() with the current component's context

### DIFF
--- a/internal/pkg/source/hq/consumer.go
+++ b/internal/pkg/source/hq/consumer.go
@@ -200,7 +200,7 @@ func (s *HQ) consumerSender(ctx context.Context, wg *sync.WaitGroup, urlBuffer <
 // only the first error will be returned.
 func (s *HQ) getURLs(batchSize int) ([]gocrawlhq.URL, error) {
 	if config.Get().HQBatchConcurrency <= 1 {
-		return s.client.Get(context.TODO(), batchSize)
+		return s.client.Get(s.ctx, batchSize)
 	}
 
 	concurrency := config.Get().HQBatchConcurrency
@@ -208,7 +208,7 @@ func (s *HQ) getURLs(batchSize int) ([]gocrawlhq.URL, error) {
 	urlsChan := make(chan []gocrawlhq.URL)
 	var allURLs []gocrawlhq.URL
 
-	g, _ := errgroup.WithContext(context.TODO())
+	g, _ := errgroup.WithContext(s.ctx)
 
 	// Start concurrent fetches
 	for range concurrency {

--- a/internal/pkg/source/hq/finisher.go
+++ b/internal/pkg/source/hq/finisher.go
@@ -187,7 +187,7 @@ func (s *HQ) finisherSender(ctx context.Context, batch *finishBatch, batchUUID s
 	logger.Debug("sending batch to HQ", "size", len(batch.URLs))
 
 	for {
-		err := s.client.Delete(context.TODO(), batch.URLs, batch.ChildsCaptured)
+		err := s.client.Delete(ctx, batch.URLs, batch.ChildsCaptured)
 		select {
 		case <-ctx.Done():
 			logger.Debug("closing")

--- a/internal/pkg/source/hq/hq.go
+++ b/internal/pkg/source/hq/hq.go
@@ -76,7 +76,7 @@ func (s *HQ) Stop() {
 		s.wg.Wait()
 		seedsToReset := reactor.GetStateTable()
 		for _, seed := range seedsToReset {
-			if err := s.client.ResetURL(context.TODO(), seed); err != nil {
+			if err := s.client.ResetURL(s.ctx, seed); err != nil {
 				logger.Error("error while reseting", "id", seed, "err", err)
 			}
 			logger.Debug("reset seed", "id", seed)

--- a/internal/pkg/source/hq/producer.go
+++ b/internal/pkg/source/hq/producer.go
@@ -173,7 +173,7 @@ func (s *HQ) producerSender(ctx context.Context, batch *producerBatch, batchUUID
 	logger.Debug("sending batch to HQ", "size", len(batch.URLs))
 
 	for {
-		err := s.client.Add(context.TODO(), batch.URLs, false) // Use bypassSeencheck = false
+		err := s.client.Add(ctx, batch.URLs, false) // Use bypassSeencheck = false
 		select {
 		case <-ctx.Done():
 			logger.Debug("closing")

--- a/internal/pkg/source/hq/seencheck.go
+++ b/internal/pkg/source/hq/seencheck.go
@@ -1,8 +1,6 @@
 package hq
 
 import (
-	"context"
-
 	"github.com/internetarchive/Zeno/pkg/models"
 	"github.com/internetarchive/gocrawlhq"
 )
@@ -56,7 +54,7 @@ func (s *HQ) SeencheckItem(item *models.Item) error {
 
 	// Get seencheck URLs from CrawlHQ
 	// If an URL is not returned it means that it was seen before
-	outputURLs, err := s.client.Seencheck(context.TODO(), URLsToSeencheck)
+	outputURLs, err := s.client.Seencheck(s.ctx, URLsToSeencheck)
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/source/lq/consumer.go
+++ b/internal/pkg/source/lq/consumer.go
@@ -43,7 +43,7 @@ func (s *LQ) consumer() {
 	// Wait for shutdown signal
 	for {
 		select {
-		case <-s.ctx.Done():
+		case <-ctx.Done():
 			logger.Debug("received done signal")
 
 			// Cancel the context to stop all goroutines.
@@ -182,7 +182,7 @@ func (s *LQ) consumerSender(ctx context.Context, wg *sync.WaitGroup, urlBuffer <
 }
 
 func (s *LQ) getURLs(batchSize int) ([]sqlc_model.Url, error) {
-	return s.client.get(context.TODO(), batchSize)
+	return s.client.get(s.ctx, batchSize)
 }
 
 func ensureAllIDsNotInReactor(URLs []sqlc_model.Url) error {

--- a/internal/pkg/source/lq/finisher.go
+++ b/internal/pkg/source/lq/finisher.go
@@ -185,7 +185,7 @@ func (s *LQ) finisherSender(ctx context.Context, batch *finishBatch, batchUUID s
 	logger.Debug("sending batch to LQ", "size", len(batch.URLs))
 
 	for {
-		err := s.client.delete(context.TODO(), batch.URLs, false)
+		err := s.client.delete(ctx, batch.URLs, false)
 		select {
 		case <-ctx.Done():
 			logger.Debug("closing")

--- a/internal/pkg/source/lq/lq.go
+++ b/internal/pkg/source/lq/lq.go
@@ -77,7 +77,7 @@ func (s *LQ) Stop() {
 		s.wg.Wait()
 		seedsToReset := reactor.GetStateTable()
 		for _, seed := range seedsToReset {
-			if err := s.client.resetURL(context.TODO(), seed); err != nil {
+			if err := s.client.resetURL(s.ctx, seed); err != nil {
 				logger.Error("error while reseting", "id", seed, "err", err)
 			}
 			logger.Debug("reset seed", "id", seed)


### PR DESCRIPTION
Note that we leave `context.TODO()` in `internal/pkg/source/hq/consumer.go` because its a special case.

Fixing issue: https://github.com/internetarchive/Zeno/issues/472