### PR TITLE
Drop panic from preprocessor seencheck

### DIFF
--- a/internal/pkg/preprocessor/preprocessor.go
+++ b/internal/pkg/preprocessor/preprocessor.go
@@ -255,7 +255,8 @@ func preprocess(workerID string, seed *models.Item) error {
 	if (config.Get().UseHQ || config.Get().UseSeencheck) && GlobalPreprocessor.seencheckerSet {
 		err = GlobalPreprocessor.Seenchecker(seed)
 		if err != nil {
-			logger.Warn("unable to seencheck seed", "err", err.Error())
+			logger.Error("unable to seencheck seed", "err", err.Error())
+			return err
 		}
 	}
 

--- a/internal/pkg/preprocessor/seencheck/seencheck.go
+++ b/internal/pkg/preprocessor/seencheck/seencheck.go
@@ -33,9 +33,9 @@ func Close() {
 }
 
 func isSeen(hash string) (found bool, value string, err error) {
-	found, err := globalSeencheck.DB.Get(hash, &value)
+	found, err = globalSeencheck.DB.Get(hash, &value)
 	if err != nil {
-		return nil, nil, err
+		return false, "", err
 	}
 
 	return found, value, nil

--- a/internal/pkg/preprocessor/seencheck/seencheck.go
+++ b/internal/pkg/preprocessor/seencheck/seencheck.go
@@ -32,13 +32,13 @@ func Close() {
 	globalSeencheck.DB.Close()
 }
 
-func isSeen(hash string) (found bool, value string) {
+func isSeen(hash string) (found bool, value string, err error) {
 	found, err := globalSeencheck.DB.Get(hash, &value)
 	if err != nil {
-		panic(err)
+		return nil, nil, err
 	}
 
-	return found, value
+	return found, value, nil
 }
 
 func seen(hash, value string) {
@@ -77,7 +77,7 @@ func SeencheckItem(item *models.Item) error {
 
 	items, err := item.GetNodesAtLevel(item.GetMaxDepth())
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	for i := range items {
@@ -95,7 +95,10 @@ func SeencheckItem(item *models.Item) error {
 			URLType = "seed"
 		}
 
-		found, foundType := isSeen(hash)
+		found, foundType, err := isSeen(hash)
+		if err != nil {
+			return err
+		}
 
 		if !found {
 			// First time seen: mark and process


### PR DESCRIPTION
Make `seencheck.isSeen` return error instead of `panic(err)`.

Make `SeencheckItem` return `err` instead of `panic(err)`.

`preprocess` should return `err` from `GlobalPreprocessor.Seenchecker` instead of just logging it.

If `preprocess` return an error, the program stops with `panic` so we have exactly the same program behavior as before but with better error handling and logging.

Also, the seencheck code is now much more cleaner and testable.

Relevant issue: https://github.com/internetarchive/Zeno/issues/473