### PR TITLE
Add HTTP cache transport and WARC deduplication fix

### DIFF
--- a/internal/pkg/archiver/http_cache_transport.go
+++ b/internal/pkg/archiver/http_cache_transport.go
@@ -1,0 +1,87 @@
+package archiver
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// cacheEntry stores info about a previous response
+type cacheEntry struct {
+	etag         string
+	lastModified string
+	timestamp    time.Time
+}
+
+// HTTPCacheTransport wraps an existing RoundTripper and implements deduplication
+type HTTPCacheTransport struct {
+	Transport http.RoundTripper
+	mu        sync.Mutex
+	cache     map[string]*cacheEntry
+}
+
+// NewHTTPCacheTransport initializes the cache wrapper
+func NewHTTPCacheTransport(base http.RoundTripper) *HTTPCacheTransport {
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return &HTTPCacheTransport{
+		Transport: base,
+		cache:     make(map[string]*cacheEntry),
+	}
+}
+
+// RoundTrip implements the http.RoundTripper interface with caching/deduplication
+func (c *HTTPCacheTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	key := req.URL.String()
+
+	c.mu.Lock()
+	entry, ok := c.cache[key]
+	c.mu.Unlock()
+
+	// If we have a cache entry, return 304 without hitting network
+	if ok && !entry.shouldRefresh() {
+		return &http.Response{
+			StatusCode: http.StatusNotModified,
+			Header:     make(http.Header),
+			Request:    req,
+			Body:       io.NopCloser(strings.NewReader("")),
+		}, nil
+	}
+
+	// Add conditional headers if we have a cache entry
+	if ok {
+		if entry.etag != "" {
+			req.Header.Set("If-None-Match", entry.etag)
+		}
+		if entry.lastModified != "" {
+			req.Header.Set("If-Modified-Since", entry.lastModified)
+		}
+	}
+
+	// Perform the actual request
+	resp, err := c.Transport.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Update cache if response is cacheable
+	if resp.StatusCode == http.StatusOK {
+		c.mu.Lock()
+		c.cache[key] = &cacheEntry{
+			etag:         resp.Header.Get("ETag"),
+			lastModified: resp.Header.Get("Last-Modified"),
+			timestamp:    time.Now(),
+		}
+		c.mu.Unlock()
+	}
+
+	return resp, nil
+}
+
+// shouldRefresh decides if cache entry is stale
+func (e *cacheEntry) shouldRefresh() bool {
+	return false
+}

--- a/internal/pkg/archiver/http_cache_transport_test.go
+++ b/internal/pkg/archiver/http_cache_transport_test.go
@@ -1,0 +1,52 @@
+package archiver
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// fakeRoundTripper counts how many times RoundTrip is called
+type fakeRoundTripper struct {
+	calls int32
+}
+
+func (f *fakeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	atomic.AddInt32(&f.calls, 1)
+
+	body := io.NopCloser(strings.NewReader("hello"))
+	return &http.Response{
+		StatusCode: 200,
+		Body:       body,
+		Header:     make(http.Header),
+		Request:    req,
+	}, nil
+}
+
+func TestHTTPCacheTransport_Deduplication(t *testing.T) {
+	// Initialize fake transport
+	fake := &fakeRoundTripper{}
+
+	// Wrap it with our cache transport
+	cacheTransport := NewHTTPCacheTransport(fake)
+
+	client := &http.Client{Transport: cacheTransport}
+
+	// First request to URL1
+	req1, _ := http.NewRequest("GET", "http://example.com/page1", nil)
+	client.Do(req1)
+
+	// Second request to same URL1 (should be skipped by cache)
+	req2, _ := http.NewRequest("GET", "http://example.com/page1", nil)
+	client.Do(req2)
+
+	// Request to a new URL2 (should hit the network)
+	req3, _ := http.NewRequest("GET", "http://example.com/page2", nil)
+	client.Do(req3)
+
+	if fake.calls != 2 {
+		t.Errorf("expected 2 actual network calls, got %d", fake.calls)
+	}
+}


### PR DESCRIPTION
This PR aims at #411 
This PR adds an HTTP caching layer for WARC clients to reduce redundant network requests. Repeated requests to the same URL are served from cache, improving deduplication and efficiency.

Changes made:
- warc.go – Wraps WARC HTTP clients with HTTPCacheTransport to enable caching/deduplication.
- http_cache_transport.go – Implements HTTPCacheTransport as a thread-safe http.RoundTripper.
- http_cache_transport_test.go – Unit test verifying that repeated requests do not trigger extra network calls.

Test Plan:
- go test ./internal/pkg/archiver 
- all tests passed