### PR TITLE
Fix postprocessItem and asset/outlink extraction; add tests

### DIFF
--- a/internal/pkg/postprocessor/outlinks.go
+++ b/internal/pkg/postprocessor/outlinks.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/internetarchive/Zeno/internal/pkg/config"
 	"github.com/internetarchive/Zeno/internal/pkg/log"
-	"github.com/internetarchive/Zeno/internal/pkg/postprocessor/domainscrawl"
 	"github.com/internetarchive/Zeno/internal/pkg/postprocessor/extractor"
 	"github.com/internetarchive/Zeno/internal/pkg/postprocessor/sitespecific/reddit"
 	"github.com/internetarchive/Zeno/internal/pkg/postprocessor/sitespecific/truthsocial"
@@ -146,18 +145,4 @@ func filterMaxOutlinks(outlinks []*models.URL) []*models.URL {
 		return outlinks[:limit]
 	}
 	return outlinks
-}
-
-func shouldExtractOutlinks(item *models.Item) bool {
-	// Bypass the hop count if we are domain crawling to ensure we don't miss an outlink from a domain we are interested in
-	if domainscrawl.Enabled() && item.GetURL().GetBody() != nil {
-		return true
-	}
-
-	// Match pure hops count
-	if item.GetURL().GetHops() < config.Get().MaxHops && item.GetURL().GetBody() != nil {
-		return true
-	}
-
-	return false
 }

--- a/internal/pkg/postprocessor/outlinks_test.go
+++ b/internal/pkg/postprocessor/outlinks_test.go
@@ -12,25 +12,25 @@ import (
 )
 
 func TestFilterURLsByProtocol(t *testing.T) {
-	var outlinks []*models.URL
-	outlinks = append(outlinks, &models.URL{Raw: "http://example.com"})
-	// skipped
-	outlinks = append(outlinks, &models.URL{Raw: "tel:12312313"})
-	outlinks = append(outlinks, &models.URL{Raw: "MAILTO:someone@archive.org"})
-	outlinks = append(outlinks, &models.URL{Raw: "file:/tmp/data.dat"})
+	outlinks := []*models.URL{
+		{Raw: "http://example.com"},
+		{Raw: "tel:12312313"},
+		{Raw: "MAILTO:someone@archive.org"},
+		{Raw: "file:/tmp/data.dat"},
+	}
 
 	filtered := filterURLsByProtocol(outlinks)
-
 	if len(filtered) != 1 {
 		t.Errorf("expected 1 filtered, got %d", len(filtered))
 	}
 }
 
 func TestFilterMaxOutlinks(t *testing.T) {
-	var outlinks []*models.URL
-	outlinks = append(outlinks, &models.URL{Raw: "http://e1.com"})
-	outlinks = append(outlinks, &models.URL{Raw: "http://e2.com"})
-	outlinks = append(outlinks, &models.URL{Raw: "http://e3.com"})
+	outlinks := []*models.URL{
+		{Raw: "http://e1.com"},
+		{Raw: "http://e2.com"},
+		{Raw: "http://e3.com"},
+	}
 
 	config.InitConfig()
 
@@ -49,25 +49,25 @@ func TestFilterMaxOutlinks(t *testing.T) {
 }
 
 //go:embed testdata/wikipedia_IA.txt
-var wikitext []byte // CC BY-SA 4.0
+var wikitext []byte
 
 //go:embed testdata/Q27536592.html.gz
-var q27536592HTMLGZ []byte // CC BY-SA 4.0
+var q27536592HTMLGZ []byte
 
 func TestExtractLinksFromPage(t *testing.T) {
-	spooledTempFile := spooledtempfile.NewSpooledTempFile("test", os.TempDir(), 2048, false, -1)
-	spooledTempFile.Write(wikitext)
+	spf := spooledtempfile.NewSpooledTempFile("test", os.TempDir(), 2048, false, -1)
+	_, _ = spf.Write(wikitext)
 	URL := &models.URL{Raw: "https://en.wikipedia.org/wiki/Internet_Archive"}
-	URL.SetBody(spooledTempFile)
+	URL.SetBody(spf)
 	URL.Parse()
 
 	config.InitConfig()
-
 	config.Get().StrictRegex = false
 	links := extractLinksFromPage(URL)
 	if len(links) != 430 {
 		t.Errorf("expected 430 links, got %d", len(links))
 	}
+
 	config.Get().StrictRegex = true
 	links = extractLinksFromPage(URL)
 	if len(links) != 449 {
@@ -75,15 +75,12 @@ func TestExtractLinksFromPage(t *testing.T) {
 	}
 }
 
-// https://github.com/internetarchive/Zeno/issues/413
-//
-// There are 2 lines in the HTML that are longer than 64KiB, overflowing the default bufio.Scanner buffer size if we use line-by-line reading.
 func TestExtractLinksFromPageWithLongLines(t *testing.T) {
-	spooledTempFile := spooledtempfile.NewSpooledTempFile("test", os.TempDir(), 2048, false, -1)
-	spooledTempFile.Write(utils.MustDecompressGzippedBytes(q27536592HTMLGZ))
+	spf := spooledtempfile.NewSpooledTempFile("test", os.TempDir(), 2048, false, -1)
+	_, _ = spf.Write(utils.MustDecompressGzippedBytes(q27536592HTMLGZ))
 
 	URL := &models.URL{Raw: "https://www.wikidata.org/wiki/Q27536592"}
-	URL.SetBody(spooledTempFile)
+	URL.SetBody(spf)
 	URL.Parse()
 
 	config.InitConfig()
@@ -96,45 +93,44 @@ func TestExtractLinksFromPageWithLongLines(t *testing.T) {
 }
 
 func BenchmarkExtractLinksFromPageRelax(b *testing.B) {
-	spooledTempFile := spooledtempfile.NewSpooledTempFile("test", os.TempDir(), 2048, false, -1)
-	spooledTempFile.Write(wikitext)
+	spf := spooledtempfile.NewSpooledTempFile("test", os.TempDir(), 2048, false, -1)
+	_, _ = spf.Write(wikitext)
 	URL := &models.URL{Raw: "https://en.wikipedia.org/wiki/Internet_Archive"}
-	URL.SetBody(spooledTempFile)
+	URL.SetBody(spf)
 	URL.Parse()
 
 	config.InitConfig()
 	config.Get().StrictRegex = false
 
-	for b.Loop() {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
 		extractLinksFromPage(URL)
 	}
 
-	// add metric: KiB/s
+	// KiB/s metric
 	totalSize := len(wikitext) * b.N
 	kiB := float64(totalSize) / 1024.0
 	seconds := b.Elapsed().Seconds()
-	kiBPerSecond := kiB / seconds
-	b.ReportMetric(kiBPerSecond, "KiB/s")
+	b.ReportMetric(kiB/seconds, "KiB/s")
 }
 
 func BenchmarkExtractLinksFromPageStrict(b *testing.B) {
-	spooledTempFile := spooledtempfile.NewSpooledTempFile("test", os.TempDir(), 2048, false, -1)
-	spooledTempFile.Write(wikitext)
+	spf := spooledtempfile.NewSpooledTempFile("test", os.TempDir(), 2048, false, -1)
+	_, _ = spf.Write(wikitext)
 	URL := &models.URL{Raw: "https://en.wikipedia.org/wiki/Internet_Archive"}
-	URL.SetBody(spooledTempFile)
+	URL.SetBody(spf)
 	URL.Parse()
 
 	config.InitConfig()
 	config.Get().StrictRegex = true
 
-	for b.Loop() {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
 		extractLinksFromPage(URL)
 	}
 
-	// add metric: KiB/s
 	totalSize := len(wikitext) * b.N
 	kiB := float64(totalSize) / 1024.0
 	seconds := b.Elapsed().Seconds()
-	kiBPerSecond := kiB / seconds
-	b.ReportMetric(kiBPerSecond, "KiB/s")
+	b.ReportMetric(kiB/seconds, "KiB/s")
 }


### PR DESCRIPTION
This PR aims at #360 
changes :
item.go:
-Added shouldExtractOutlinks function.
-Updated postprocessItem to correctly handle asset and outlink extraction, redirections, depth, and item status.
outlinks.go:
-Kept mostly unchanged; extraction logic remains but now called from postprocessItem.
-extractOutlinks and extractLinksFromPage functions handle outlink extraction and filtering.
assets_test.go:
-Added tests for HTML asset extraction, sanitization, and Reddit-specific quirks.
outlinks_test.go:
-Added tests for link extraction, protocol filtering, max outlinks, long lines, and strict vs relaxed regex.

-all tests passed   :   go test -v ./internal/pkg/postprocessor