### PR TITLE
fix: connection is nil

### DIFF
--- a/internal/pkg/archiver/general/archiver.go
+++ b/internal/pkg/archiver/general/archiver.go
@@ -151,7 +151,7 @@ func ArchiveItem(item *models.Item, wg *sync.WaitGroup, guard chan struct{}, glo
 
 	resp.Body = &connutil.BodyWithConn{ // Wrap the response body to hold the connection
 		ReadCloser: resp.Body,
-		Conn:       <-wrappedConnChan,
+		Conn:       conn,
 	}
 
 	// Set the response in the URL

--- a/internal/pkg/archiver/general/body.go
+++ b/internal/pkg/archiver/general/body.go
@@ -27,11 +27,11 @@ func ProcessBody(u *models.URL, disableAssetsCapture, domainsCrawl bool, maxHops
 	// Retrieve the underlying *warc.CustomConnection if available (In unit tests, this may not be set)
 	var conn *warc.CustomConnection
 	bodyWithConn, ok := u.GetResponse().Body.(*connutil.BodyWithConn)
-	if ok {
+	if ok && bodyWithConn.Conn != nil {
 		conn = bodyWithConn.Conn
 	} else {
 		if logger != nil {
-			logger.Warn("Response body is not a *BodyWithConn, connection may not be closed properly on error")
+			logger.Warn("Response body is not a *BodyWithConn with a valid connection, connection may not be closed properly on error")
 		}
 	}
 


### PR DESCRIPTION
This bug was introduced in #356.

I guess that when I refactored two archiver.go files to achieve headless functionality, I somehow copied and pasted the resp.Body code from headless/archiver directly into general/archiver.

I'm not sure about the actual impact of this issue; could it lead to leaked connections?