### PR TITLE
Revert "workaround: add recover to prevent panic in PDF outlink extractor"

### DIFF
--- a/internal/pkg/postprocessor/extractor/pdf.go
+++ b/internal/pkg/postprocessor/extractor/pdf.go
@@ -1,8 +1,6 @@
 package extractor
 
 import (
-	"fmt"
-
 	"github.com/internetarchive/Zeno/pkg/models"
 
 	pdfapi "github.com/pdfcpu/pdfcpu/pkg/api"
@@ -27,13 +25,6 @@ func (PDFOutlinkExtractor) Match(URL *models.URL) bool {
 
 func (PDFOutlinkExtractor) Extract(URL *models.URL) (outlinks []*models.URL, err error) {
 	defer URL.RewindBody()
-	defer func() {
-		if r := recover(); r != nil {
-			// TODO: remove this workaround once an new version of pdfcpu is released
-			// https://github.com/pdfcpu/pdfcpu/issues/1193
-			err = fmt.Errorf("pdf outlink extractor panicked: %v", r)
-		}
-	}()
 
 	annots, err := pdfapi.Annotations(URL.GetBody(), nil, nil)
 	if err != nil {


### PR DESCRIPTION
Reverts internetarchive/Zeno#565

We are already using github.com/pdfcpu/pdfcpu v0.11.1. (dependabot upgraded it.).