### PR TITLE
Fix nil entries in flattenTree to prevent potential nil dereference

### DIFF
--- a/pkg/models/item_dedupe.go
+++ b/pkg/models/item_dedupe.go
@@ -38,10 +38,10 @@ func flattenTree(root *Item) []*Item {
 	var nodes []*Item
 	var traverse func(node *Item)
 	traverse = func(node *Item) {
-		nodes = append(nodes, node)
 		if node == nil {
 			return
 		}
+		nodes = append(nodes, node)
 		for _, child := range node.GetChildren() {
 			traverse(child)
 		}


### PR DESCRIPTION
This PR fixes a correctness issue in flattenTree (pkg/models/item_dedupe.go) where a node was appended to the result slice before checking whether it was nil.

As a result, nil entries could be added to the nodes slice, which is unintended and creates a latent risk of nil-dereference panics in downstream logic.